### PR TITLE
fix: 修复长条图片无法检测到文本

### DIFF
--- a/src/paddleocr-ncnn/details.cpp
+++ b/src/paddleocr-ncnn/details.cpp
@@ -34,7 +34,7 @@ std::vector<std::vector<std::vector<int>>> Details::detectText(const cv::Mat &sr
     int w = src.cols;
     int h = src.rows;
 
-    //输入图片固定尺寸960*960
+    //1.缩减尺寸
     float ratio = 1.f;
     if (std::max(w, h) > 960) {
         if (h > w) {
@@ -47,9 +47,23 @@ std::vector<std::vector<std::vector<int>>> Details::detectText(const cv::Mat &sr
     int resizeH = int(h * ratio);
     int resizeW = int(w * ratio);
 
-    resizeH = std::max(int(round(float(resizeH) / 32) * 32), 32);
-    resizeW = std::max(int(round(float(resizeW) / 32) * 32), 32);
+    //2.扩大尺寸，确保图片的最短的边大于等于64,小于这个值可能会导致检测不到文字
+    float ratio2 = 1.f;
+    if (std::min(resizeW, resizeH) < 64) {
+        if (resizeH > resizeW) {
+            ratio2 = 64.0f / resizeW;
+        } else {
+            ratio2 = 64.0f / resizeH;
+        }
+    }
+    resizeH = int(resizeH * ratio2);
+    resizeW = int(resizeW * ratio2);
 
+    //3.标准化图片尺寸，否则会错位
+    resizeH = int(round(float(resizeH) / 32) * 32);
+    resizeW = int(round(float(resizeW) / 32) * 32);
+
+    //执行resize，记录变换比例
     cv::Mat resize_img;
     cv::resize(src, resize_img, cv::Size(resizeW, resizeH));
     float ratio_h = float(resizeH) / float(h);


### PR DESCRIPTION
原因是当图片高度或宽度低于一定值后，检测算法难以执行检测
经过测试，图片的短边大于等于64的时候即可满足检测算法的要求
修改方法为在预先缩减图片尺寸后，进一步判断图片的短边是否符合大于等于64的要求，对不符合的执行第二次尺寸计算

Log: 修复长条图片无法检测到文本