### PR TITLE
fix: 修复单行文本的顺序问题

### DIFF
--- a/src/paddleocr-ncnn/paddleocr.cpp
+++ b/src/paddleocr-ncnn/paddleocr.cpp
@@ -132,7 +132,7 @@ QString PaddleOCRApp::getRecogitionResult(const QImage &image)
 
     //组装识别结果，注意：目前没有版面识别功能，只能这样简单堆叠，然后将结果刷到界面上
     QString text;
-    std::for_each(result.rbegin(), result.rend(), [&text](const std::string & eachText) {
+    std::for_each(result.begin(), result.end(), [&text](const std::string & eachText) {
         text += QString(eachText.c_str());
         text += "\n";
     });


### PR DESCRIPTION
现象是单行文本有几率顺序错乱，而不是固定的从左到右
原因是检测网络内部问题，输出的结果如此
解决方法是在裁切图片之前，添加一步排序的操作，确保文本的顺序正常

Log: 修复单行文本的顺序问题
Bug: https://pms.uniontech.com/bug-view-138315.html