### PR TITLE
chore: try find ncnn from system first

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,9 +37,12 @@ add_library(opencv_world STATIC IMPORTED)
 set_property(TARGET opencv_world PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/opencv-4.5.4/build/install/lib/libopencv_world.a)
 
 #for ncnn
-include_directories(../3rdparty/ncnn/build/install/include/ncnn)
-add_library(ncnn STATIC IMPORTED)
-set_property(TARGET ncnn PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/ncnn/build/install/lib/libncnn.a)
+find_package(ncnn PATHS ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/ncnn/build/install/lib/cmake/ncnn)
+if (NOT ncnn_FOUND)
+    include_directories(${CMAKE_CURRENT_LIST_DIR}/../3rdparty/ncnn/build/install/include/ncnn)
+    add_library(ncnn STATIC IMPORTED)
+    set_property(TARGET ncnn PROPERTY IMPORTED_LOCATION ${CMAKE_CURRENT_LIST_DIR}/../3rdparty/ncnn/build/install/lib/libncnn.a)
+endif()
 
 #for clipper
 include_directories(../3rdparty/clipper)


### PR DESCRIPTION
在系统中试图查找并使用系统的 ncnn, 找不到时再使用原方案。

大多数发行版在打包应用时会尽可能不使用项目所附带（vendor）的未修改的第三方库，这样的修改可使其它发行版更容易接受我们的项目。

另注：此项目也附带了 opencv，此修改并未尝试调整查找 opencv 的方式，但也应当考虑做相同的修改。