### PR TITLE
fix: 修复初始弹出界面后，左侧图片可以轻微挪动

### DIFF
--- a/src/view/imageview.cpp
+++ b/src/view/imageview.cpp
@@ -99,7 +99,7 @@ qreal ImageView::windowRelativeScale() const
 }
 void ImageView::fitWindow()
 {
-    qreal wrs = windowRelativeScale();
+    qreal wrs = windowRelativeScale() * 0.95; //未知原因导致fitwindow后仍然可以小范围滑动图片，此处乘以0.95以抵消滑动
     m_scal = wrs;
     resetTransform();
     scale(wrs, wrs);


### PR DESCRIPTION
原因未知，fitwindow的算法和看图一致，但这里会触发滑动
解决方法是将图片尺寸再*0.95，在确保图片大小基本不变的情况下，初始状态不可滑动

Log: 修复初始弹出界面后，左侧图片可以轻微挪动
Bug: https://pms.uniontech.com/bug-view-160831.html