### PR TITLE
fix: set CMAKE_INSTALL_LIBDIR as lib

### DIFF
--- a/build3rdparty.sh
+++ b/build3rdparty.sh
@@ -21,7 +21,7 @@ rm -rf modules/highgui
 cp -r ../opencv-mobile/highgui modules/
 patch -p1 -i ../opencv-mobile/opencv-4.5.4-no-rtti.patch
 rm -rf build && mkdir build && cd build
-cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_BUILD_TYPE=Release `cat ../../opencv-mobile/opencv4_cmake_options.txt` -DBUILD_opencv_world=ON ..
+cmake -DCMAKE_INSTALL_PREFIX=install -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_BUILD_TYPE=Release `cat ../../opencv-mobile/opencv4_cmake_options.txt` -DBUILD_opencv_world=ON ..
 make -j$JOBS && make install
 cd ../../..
 fi


### PR DESCRIPTION
Log: opencv 引入时使用 3rdparty/opencv-4.5.4/build/install/lib/libopencv_world.a，写死了 lib 路径，但是 CMAKE_INSTALL_LIBDIR 在一些 64 位系统中是 lib64