### PR TITLE
fix: export file delay

### DIFF
--- a/src/mainwidget.cpp
+++ b/src/mainwidget.cpp
@@ -599,7 +599,7 @@ void MainWidget::slotExport()
     QFile file(path);
     if (file.open(QFile::WriteOnly | QFile::Text)) {
         QTextStream out(&file);
-        out << m_plainTextEdit->document()->toPlainText();
+        out << m_plainTextEdit->document()->toPlainText() << endl;
     }
 }
 


### PR DESCRIPTION
use `endl` to push write buffer into the device (flush QTextStream)