### PR TITLE
feat: support Qt6.8 and bump version to 6.5.0

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-ocr (6.5.0) unstable; urgency=medium
+
+  * feat: enable Qt6 build and switch to Qt6.8
+
+ -- renbin <renbin@uniontech.com>  Mon, 20 Jan 2025 10:59:07 +0800
+
 deepin-ocr (1.5.1) unstable; urgency=medium
 
   *remove env kwayland-shell  

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,14 @@ Source: deepin-ocr
 Section: utils
 Priority: optional
 Maintainer: Deepin Packages Builder <packages@deepin.com>
-Build-Depends: debhelper (>= 11), cmake, qtbase5-dev, pkg-config, libdtkwidget-dev (>= 5.6), qttools5-dev-tools, qttools5-dev, libdtkocr-dev
+Build-Depends: debhelper (>= 11),
+ cmake,
+ pkg-config,
+ qt6-base-dev,
+ qt6-tools-dev,
+ qt6-tools-dev-tools,
+ libdtk6widget-dev,
+ libdtk6ocr-dev
 Standards-Version: 4.1.3
 Homepage: http://www.deepin.org/
 

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,7 +1,7 @@
 package:
   id: org.deepin.ocr
   name: "deepin-ocr"
-  version: 1.1.0
+  version: 6.5.0.1
   kind: app
   description: |
     Ocr is a text recognition software.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,23 @@
 cmake_minimum_required(VERSION 3.10)
 project(deepin-ocr)
 
-#玲珑构建依赖目录
+set(ENABLE_Qt6 ON CACHE BOOL "Build with Qt6")
+find_package(Qt6 QUIET)
+
+if(ENABLE_Qt6 AND Qt6_FOUND)
+    set(DTK_VERSION_MAJOR 6)
+    set(QT_VERSION_MAJOR 6)
+    set(SUPPORT_QT6 TRUE)
+else()
+    set(QT_VERSION_MAJOR 5)
+endif()
+
+message(STATUS "--- Current Qt verison: ${QT_VERSION_MAJOR}")
+
+# 玲珑构建依赖目录
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
 
-#for Qt
+# for Qt
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -19,6 +32,7 @@ set(QtModule Core Gui Widgets DBus LinguistTools)
 
 if(DOTEST)
     set(QtModule ${QtModule} Test)
+
     if(CMAKE_HOST_SYSTEM_PROCESSOR MATCHES "mips64")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fprofile-arcs -ftest-coverage")
     else()
@@ -26,28 +40,22 @@ if(DOTEST)
     endif()
 endif()
 
-find_package(Qt5 REQUIRED ${QtModule})
+find_package(Qt${QT_VERSION_MAJOR} REQUIRED ${QtModule})
 
-include_directories(
-    ${Qt5Core_INCLUDE_DIRS}
-    ${Qt5Gui_INCLUDE_DIRS}
-    ${Qt5Widgets_INCLUDE_DIRS}
-    ${Qt5DBus_INCLUDE_DIRS}
-)
 add_definitions(${QT_DEFINITIONS})
 
 include(CMakePackageConfigHelpers)
 
-#for ocr plugin manager
-#find_package(dtkocr)
-#include_directories(${dtkocr_INCLUDE_DIRS})
+# for ocr plugin manager
+# find_package(dtkocr)
+# include_directories(${dtkocr_INCLUDE_DIRS})
 
-#for OpenMP
+# for OpenMP
 find_package(OpenMP REQUIRED)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fopenmp")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fopenmp")
 
-#for project files
+# for project files
 include_directories(.)
 include_directories(view)
 include_directories(service)
@@ -58,22 +66,28 @@ aux_source_directory(./view allSource)
 aux_source_directory(./service allSource)
 aux_source_directory(./engine allSource)
 
-#translation
+# translation
 file(GLOB TargetTsFiles LIST_DIRECTORIES false ../translations/${PROJECT_NAME}*.ts)
 set_directory_properties(PROPERTIES CLEAN_NO_CUSTOM 1)
-if (NOT (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
-    qt5_create_translation(LangSrcs ${allSource} ${TargetTsFiles}
-        OPTIONS )
+
+if(NOT(${CMAKE_BUILD_TYPE} MATCHES "Debug"))
+    if(SUPPORT_QT6)
+        qt_create_translation(LangSrcs ${allSource} ${TargetTsFiles} OPTIONS)
+        qt_add_translation(${TargetTsFiles})
+    else()
+        qt5_create_translation(LangSrcs ${allSource} ${TargetTsFiles} OPTIONS)
+        qt5_add_translation(${TargetTsFiles})
+    endif()
 endif()
-qt5_add_translation(${TargetTsFiles})
+
 set_source_files_properties(${qmfiles} PROPERTIES OUTPUT_LOCATION "translations")
 
-#QRC file
+# QRC file
 set(AllQRC ../resource.qrc)
 
 add_executable(${PROJECT_NAME} ${allSource} ${LangSrcs} ${AllQRC})
 
-#for test
+# for test
 if(DOTEST)
     SET(PROJECT_NAME_TEST ${PROJECT_NAME}_test)
 
@@ -94,14 +108,14 @@ if(DOTEST)
         "./mainwindow.cpp"
         "./resulttextview.cpp"
         "./textloadwidget.cpp"
-        )
+    )
 
     add_executable(${PROJECT_NAME_TEST} ${allHeaders} ${allTestSource} ${allTestSource1})
     target_link_libraries(${PROJECT_NAME_TEST} gmock gtest pthread)
 
     add_test(${PROJECT_NAME_TEST} COMMAND ${PROJECT_NAME_TEST})
 
-#------------------------------ 创建'make test'指令---------------------------------------
+    # ------------------------------ 创建'make test'指令---------------------------------------
     add_custom_target(test
         COMMAND mkdir -p coverageResult
         WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -128,31 +142,46 @@ if(DOTEST)
     add_dependencies(test ${PROJECT_NAME_TEST})
 endif()
 
-#for dtk
+# for dtk
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(dtk_lib REQUIRED dtkwidget dtkcore dtkocr)
-target_include_directories(${PROJECT_NAME} PUBLIC ${dtk_lib_INCLUDE_DIRS})
+pkg_check_modules(ocr_lib REQUIRED dtk6ocr)
+target_include_directories(${PROJECT_NAME} PUBLIC ${ocr_lib_INCLUDE_DIRS})
+find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core Widget)
 
-if(DOTEST)
-    target_include_directories(${PROJECT_NAME_TEST} PUBLIC ${dtk_lib_INCLUDE_DIRS})
+if(NOT SUPPORT_QT6)
+    qt5_use_modules(${PROJECT_NAME} ${QtModule})
 endif()
 
-qt5_use_modules(${PROJECT_NAME} ${QtModule})
-
-if(DOTEST)
+if(DOTEST AND NOT SUPPORT_QT6)
     qt5_use_modules(${PROJECT_NAME_TEST} ${QtModule})
 endif()
 
-target_link_libraries(${PROJECT_NAME} Qt5::Core Qt5::Gui Qt5::Widgets ${dtk_lib_LIBRARIES} pthread)
+target_link_libraries(${PROJECT_NAME}
+    Qt${QT_VERSION_MAJOR}::Core
+    Qt${QT_VERSION_MAJOR}::Gui
+    Qt${QT_VERSION_MAJOR}::Widgets
+    Dtk${DTK_VERSION_MAJOR}::Core
+    Dtk${DTK_VERSION_MAJOR}::Widget
+    ${ocr_lib_LIBRARIES}
+    pthread
+)
 
 if(DOTEST)
-    target_link_libraries(${PROJECT_NAME_TEST} Qt5::Core Qt5::Gui Qt5::Widgets ${dtk_lib_LIBRARIES} pthread)
+    target_link_libraries(${PROJECT_NAME_TEST}
+        Qt${QT_VERSION_MAJOR}::Core
+        Qt${QT_VERSION_MAJOR}::Gui
+        Qt${QT_VERSION_MAJOR}::Widgets
+        Dtk${DTK_VERSION_MAJOR}::Core
+        Dtk${DTK_VERSION_MAJOR}::Widget
+        ${ocr_lib_LIBRARIES}
+        pthread
+    )
 endif()
 
-#dde项目，期望CMAKE_INSTALL_PREFIX为/usr
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+# dde项目，期望CMAKE_INSTALL_PREFIX为/usr
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
     set(CMAKE_INSTALL_PREFIX /usr)
-endif ()
+endif()
 
 # install
 set(PREFIX ${CMAKE_INSTALL_PREFIX})
@@ -162,11 +191,11 @@ set(AppIconDir ${PREFIX}/share/icons/hicolor/scalable/apps)
 set(DBusServiceDir ${PREFIX}/share/dbus-1/services)
 
 install(TARGETS ${PROJECT_NAME}
-        EXPORT ${PROJECT_NAME}Targets
-        LIBRARY DESTINATION ${PREFIX}/lib
-        ARCHIVE DESTINATION lib
-        RUNTIME DESTINATION ${PREFIX}/bin
-        INCLUDES DESTINATION allHeaders)
+    EXPORT ${PROJECT_NAME}Targets
+    LIBRARY DESTINATION ${PREFIX}/lib
+    ARCHIVE DESTINATION lib
+    RUNTIME DESTINATION ${PREFIX}/bin
+    INCLUDES DESTINATION allHeaders)
 
 install(FILES ${LangSrcs} DESTINATION ${TranslationDir})
 install(FILES ../deepin-ocr.desktop DESTINATION ${DesktopDir})

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,7 +28,10 @@ int main(int argc, char *argv[])
         return 0;
     }
 
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     DGuiApplicationHelper::setUseInactiveColorGroup(false);
+#endif
+
 #if(DTK_VERSION < DTK_VERSION_CHECK(5,4,0,0))
     DApplication::loadDXcbPlugin();
     QScopedPointer<DApplication> app(new DApplication(argc, argv));

--- a/src/service/dbusocr_adaptor.h
+++ b/src/service/dbusocr_adaptor.h
@@ -12,7 +12,6 @@ class QByteArray;
 template<class T> class QList;
 template<class Key, class Value> class QMap;
 class QString;
-class QStringList;
 class QVariant;
 QT_END_NAMESPACE
 

--- a/src/view/imageview.cpp
+++ b/src/view/imageview.cpp
@@ -122,7 +122,11 @@ void ImageView::RotateImage(const int &index)
 {
     if (!m_pixmapItem && scene()) return;
     QPixmap pixmap = m_pixmapItem->pixmap();
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    QTransform rotate;
+#else
     QMatrix rotate;
+#endif
     rotate.rotate(index);
 
     pixmap = pixmap.transformed(rotate, Qt::FastTransformation);
@@ -243,8 +247,13 @@ void ImageView::resizeEvent(QResizeEvent *event)
 
 void ImageView::wheelEvent(QWheelEvent *event)
 {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    qreal factor = qPow(1.2, event->angleDelta().y() / 240.0);
+    scaleAtPoint(event->position().toPoint(), factor);
+#else
     qreal factor = qPow(1.2, event->delta() / 240.0);
     scaleAtPoint(event->pos(), factor);
+#endif
 
     event->accept();
 }


### PR DESCRIPTION
[feat: enable Qt6 build and switch to Qt6.8](https://github.com/linuxdeepin/deepin-ocr/commit/1fa81acd76e196e9c1ed99e961309a1acec7e4db) 

- Enable Qt6 build and update to Qt6.8
- Update library names and dependencies for Qt6

Log: Adapt Qt6.8

[chore: Bump version to 6.5.0](https://github.com/linuxdeepin/deepin-ocr/commit/7cfe57c598140abfad84df9a9998101e06207f17) 

Bump version to 6.5.0

Log: Bump version to 6.5.0