### PR TITLE
chore: update build dependencies in debian/control

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-ocr (6.5.3) unstable; urgency=medium
+
+  * chore: update build dependencies in debian/control
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Thu, 19 Jun 2025 22:17:22 +0800
+
 deepin-ocr (6.5.2) unstable; urgency=medium
 
   * chore: update build dependencies and CMake configuration

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Build-Depends: debhelper (>= 11),
  qt6-tools-dev,
  qt6-tools-dev-tools,
  libdtk6widget-dev,
- libdtk6ocr-dev
+ libdtk6ocr-dev,
  libncnn-dev,
  libopencv-mobile-dev
 Standards-Version: 4.1.3

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,7 +1,7 @@
 package:
   id: org.deepin.ocr
   name: "deepin-ocr"
-  version: 6.5.1.1
+  version: 6.5.2.1
   kind: app
   description: |
     Ocr is a text recognition software.


### PR DESCRIPTION
chore: update build dependencies in debian/control
    
    - Added a missing comma for libdtk6ocr-dev in the build dependencies list to ensure proper parsing.