### PR TITLE
chore: update CMake configuration for non-sw_64 architectures

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+deepin-ocr (6.5.4) unstable; urgency=medium
+
+  * chore: update CMake configuration for non-sw_64 architectures
+
+ -- dengzhongyuan <dengzhongyuan@uniontech.com>  Fri, 20 Jun 2025 16:37:22 +0800
+
 deepin-ocr (6.5.3) unstable; urgency=medium
 
   * chore: update build dependencies in debian/control

--- a/linglong.yaml
+++ b/linglong.yaml
@@ -1,7 +1,7 @@
 package:
   id: org.deepin.ocr
   name: "deepin-ocr"
-  version: 6.5.2.1
+  version: 6.5.3.1
   kind: app
   description: |
     Ocr is a text recognition software.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,6 +44,13 @@ if(DOTEST)
     endif()
 endif()
 
+if (NOT ${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wl,--as-need -fPIE")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error=incompatible-pointer-types -fPIC")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wl,--as-need -fPIE -Wno-error=incompatible-pointer-types")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -pie")
+endif()
+
 find_package(Qt${QT_VERSION_MAJOR} REQUIRED ${QtModule})
 
 add_definitions(${QT_DEFINITIONS})


### PR DESCRIPTION
chore: update CMake configuration for non-sw_64 architectures
    
    - Added additional compiler flags for better compatibility and warning management when the system processor is not sw_64.