### PR TITLE
fix: On some device models, using GPU acceleration causes crashes.

### DIFF
--- a/assets/configs/deepin-ocr.common.json
+++ b/assets/configs/deepin-ocr.common.json
@@ -1,0 +1,17 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "IsGpuEnable": {
+            "value": true,
+            "serial": 0,
+            "flags": ["global"],
+            "name": "Using GPU acceleration on special machine",
+            "name[zh_CN]": "在特殊机型上是否使用GPU加速",
+            "description": "Using GPU acceleration on special machine",
+            "description[zh_CN]":"在特殊机型上是否使用GPU加速",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/install_dconfig.cmake
+++ b/install_dconfig.cmake
@@ -1,0 +1,30 @@
+# expect that all dconfigs of plugin is saved in ./assets/configs
+function(INSTALL_DCONFIG CONFIG_NAME)
+    set(DConfigPath ${CMAKE_SOURCE_DIR}/assets/configs)
+    message("DConfigPath: ${DConfigPath}")
+    set(AppId "deepin-ocr")
+    set(ConfigName ${CONFIG_NAME})
+
+    if (DEFINED DSG_DATA_DIR)
+        message("-- DConfig is supported by DTK")
+        message("---- AppId: ${AppId}")
+        message("---- Base: ${DConfigPath}")
+        message("---- Files: ${DConfigPath}/${ConfigName}")
+        if(COMMAND dtk_add_config_meta_files)
+            message(STATUS "Using dtk_add_config_meta_files")
+            dtk_add_config_meta_files(APPID ${AppId}
+                BASE ${DConfigPath}
+                FILES ${DConfigPath}/${ConfigName})
+        else()
+            message(STATUS "Using dconfig_meta_files")
+            dconfig_meta_files(APPID ${AppId}
+                BASE ${DConfigPath}
+                FILES ${DConfigPath}/${ConfigName})
+        endif()
+    else()
+        set(DSG_DATA_DIR ${CMAKE_INSTALL_PREFIX}/share/dsg)
+        message("-- DConfig is NOT supported by DTK, install files into target path")
+        message("---- InstallTargetDir: ${DSG_DATA_DIR}/configs")
+        install(FILES ${DConfigPath}/${ConfigName} DESTINATION ${DSG_DATA_DIR}/configs/${AppId})
+    endif()
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -52,11 +52,13 @@ include_directories(.)
 include_directories(view)
 include_directories(service)
 include_directories(engine)
+include_directories(utils)
 
 aux_source_directory(. allSource)
 aux_source_directory(./view allSource)
 aux_source_directory(./service allSource)
 aux_source_directory(./engine allSource)
+aux_source_directory(./utils allSource)
 
 #translation
 file(GLOB TargetTsFiles LIST_DIRECTORIES false ../translations/${PROJECT_NAME}*.ts)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -174,3 +174,6 @@ install(FILES ${LangSrcs} DESTINATION ${TranslationDir})
 install(FILES ../deepin-ocr.desktop DESTINATION ${DesktopDir})
 install(FILES ../assets/deepin-ocr.svg DESTINATION ${AppIconDir})
 install(FILES ../com.deepin.Ocr.service DESTINATION ${DBusServiceDir})
+
+include(${CMAKE_SOURCE_DIR}/install_dconfig.cmake)
+INSTALL_DCONFIG("deepin-ocr.common.json")

--- a/src/engine/OCREngine.cpp
+++ b/src/engine/OCREngine.cpp
@@ -6,6 +6,8 @@
 #include <DOcr>
 #include <QProcess>
 #include <QFileInfo>
+#include <QDebug>
+#include <dconfigmanager.h>
 
 OCREngine *OCREngine::instance()
 {
@@ -27,6 +29,11 @@ OCREngine::OCREngine()
     ocrDriver = new Dtk::Ocr::DOcr;
     ocrDriver->loadDefaultPlugin();
     ocrDriver->setUseMaxThreadsCount(2);
+    if (!isGpuEnable()) {
+        qWarning() << "GPU is not enabled";
+        return;
+    }
+
     QProcess kxProc;
     kxProc.setProgram("bash");
     kxProc.setArguments({"-c", "lscpu | grep name"});
@@ -62,4 +69,9 @@ bool OCREngine::setLanguage(const QString &language)
     }
 
     return ocrDriver->setLanguage(language);
+}
+
+bool OCREngine::isGpuEnable()
+{
+    return DConfigManager::instance()->value(COMMON_GROUP, COMMON_ISGPUENABLE, true).toBool();
 }

--- a/src/engine/OCREngine.h
+++ b/src/engine/OCREngine.h
@@ -33,6 +33,12 @@ public:
 private:
     OCREngine();
     ~OCREngine() = default;
+    // 删除拷贝构造函数和赋值运算符，防止拷贝实例
+    OCREngine(const OCREngine &) = delete;
+    OCREngine &operator=(const OCREngine &) = delete;
+
+    // 某些机型，使用GPU进行OCR识别，会导致OCR崩溃
+    bool isGpuEnable();
 
     Dtk::Ocr::DOcr *ocrDriver;
     std::atomic_bool m_isRunning;

--- a/src/utils/dconfigmanager.cpp
+++ b/src/utils/dconfigmanager.cpp
@@ -1,0 +1,162 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "dconfigmanager.h"
+#include "private/dconfigmanager_p.h"
+
+#include <DConfig>
+
+#include <QDebug>
+
+static constexpr char kCfgAppId[] { "deepin-ocr" };
+
+DCORE_USE_NAMESPACE
+
+DConfigManager::DConfigManager(QObject *parent)
+    : QObject(parent), d(new DConfigManagerPrivate(this))
+{
+
+}
+
+DConfigManager *DConfigManager::instance()
+{
+    static DConfigManager ins;
+    return &ins;
+}
+
+DConfigManager::~DConfigManager()
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QWriteLocker locker(&d->lock);
+
+    auto configs = d->configs.values();
+    std::for_each(configs.begin(), configs.end(), [](DConfig *cfg) { delete cfg; });
+    d->configs.clear();
+#endif
+}
+
+bool DConfigManager::addConfig(const QString &config, QString *err)
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QWriteLocker locker(&d->lock);
+
+    if (d->configs.contains(config)) {
+        if (err)
+            *err = "config is already added";
+        return false;
+    }
+
+    auto cfg = DConfig::create(kCfgAppId, config, "", this);
+    if (!cfg) {
+        if (err)
+            *err = "cannot create config";
+        return false;
+    }
+
+    if (!cfg->isValid()) {
+        if (err)
+            *err = "config is not valid";
+        delete cfg;
+        return false;
+    }
+
+    d->configs.insert(config, cfg);
+    locker.unlock();
+    connect(cfg, &DConfig::valueChanged, this, [=](const QString &key) { Q_EMIT valueChanged(config, key); });
+#endif
+    return true;
+}
+
+bool DConfigManager::removeConfig(const QString &config, QString *err)
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QWriteLocker locker(&d->lock);
+
+    if (d->configs.contains(config)) {
+        delete d->configs[config];
+        d->configs.remove(config);
+    }
+#endif
+    return true;
+}
+
+QStringList DConfigManager::keys(const QString &config) const
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QReadLocker locker(&d->lock);
+
+    if (!d->configs.contains(config))
+        return QStringList();
+
+    return d->configs[config]->keyList();
+#else
+    return QStringList();
+#endif
+}
+
+bool DConfigManager::contains(const QString &config, const QString &key) const
+{
+    return key.isEmpty() ? false : keys(config).contains(key);
+}
+
+QVariant DConfigManager::value(const QString &config, const QString &key, const QVariant &fallback) const
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QReadLocker locker(&d->lock);
+
+    if (d->configs.contains(config)) {
+        // 如果DConfig没刷新，存在有config但没key的情况
+        if (!this->contains(config, key)) {
+            qWarning() << "DConfig has no key:" << key << "in config:" << config << "REBOOT may fix it";
+            return fallback;
+        }
+
+        //qDebug() << "dconfig:" << config << "key:" << key << "value:" << d->configs.value(config)->value(key, fallback);
+        return d->configs.value(config)->value(key, fallback);
+    }
+    else
+        qWarning() << "Config:" << config << "is not registered!!!";
+    return fallback;
+#else
+    return fallback;
+#endif
+}
+
+void DConfigManager::setValue(const QString &config, const QString &key, const QVariant &value)
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QReadLocker locker(&d->lock);
+
+    if (d->configs.contains(config)) {
+        // 如果DConfig没刷新，存在有config但没key的情况
+        if (!this->contains(config, key)) {
+            qWarning() << "DConfig has no key:" << key << "in config:" << config << "REBOOT may fix it";
+            return;
+        }
+
+        qInfo() << "dconfig:" << config << "key:" << key << "value:" << value;
+        d->configs.value(config)->setValue(key, value);
+    } else {
+        qWarning() << "Config:" << config << "is not registered!!!";
+    }
+#endif
+}
+
+bool DConfigManager::validateConfigs(QStringList &invalidConfigs) const
+{
+#ifdef DTKCORE_CLASS_DConfig
+    QReadLocker locker(&d->lock);
+
+    bool ret = true;
+    for (auto iter = d->configs.cbegin(); iter != d->configs.cend(); ++iter) {
+        bool valid = iter.value()->isValid();
+        if (!valid)
+            invalidConfigs << iter.key();
+        ret &= valid;
+    }
+    return ret;
+#else
+    return true;
+#endif
+}

--- a/src/utils/dconfigmanager.cpp
+++ b/src/utils/dconfigmanager.cpp
@@ -16,7 +16,7 @@ DCORE_USE_NAMESPACE
 DConfigManager::DConfigManager(QObject *parent)
     : QObject(parent), d(new DConfigManagerPrivate(this))
 {
-
+    addConfig(COMMON_GROUP);
 }
 
 DConfigManager *DConfigManager::instance()

--- a/src/utils/dconfigmanager.h
+++ b/src/utils/dconfigmanager.h
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DCONFIGMANAGER_H
+#define DCONFIGMANAGER_H
+
+#include <QObject>
+#include <QVariant>
+
+class DConfigManagerPrivate;
+class DConfigManager : public QObject
+{
+    Q_OBJECT
+    Q_DISABLE_COPY(DConfigManager)
+
+public:
+    static DConfigManager *instance();
+
+    bool addConfig(const QString &config, QString *err = nullptr);
+    bool removeConfig(const QString &config, QString *err = nullptr);
+
+    QStringList keys(const QString &config) const;
+    bool contains(const QString &config, const QString &key) const;
+    QVariant value(const QString &config, const QString &key, const QVariant &fallback = QVariant()) const;
+    void setValue(const QString &config, const QString &key, const QVariant &value);
+
+    bool validateConfigs(QStringList &invalidConfigs) const;
+
+Q_SIGNALS:
+    void valueChanged(const QString &config, const QString &key);
+
+private:
+    explicit DConfigManager(QObject *parent = nullptr);
+    virtual ~DConfigManager() override;
+
+private:
+    QScopedPointer<DConfigManagerPrivate> d;
+};
+
+#endif   // DCONFIGMANAGER_H

--- a/src/utils/dconfigmanager.h
+++ b/src/utils/dconfigmanager.h
@@ -8,6 +8,9 @@
 #include <QObject>
 #include <QVariant>
 
+#define COMMON_GROUP "deepin-ocr.common"
+#define COMMON_ISGPUENABLE "IsGpuEnable"
+
 class DConfigManagerPrivate;
 class DConfigManager : public QObject
 {

--- a/src/utils/private/dconfigmanager_p.h
+++ b/src/utils/private/dconfigmanager_p.h
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2022 - 2023 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#ifndef DCONFIGMANAGER_P_H
+#define DCONFIGMANAGER_P_H
+
+#include <dtkcore_global.h>
+#include <QMap>
+#include <QReadWriteLock>
+
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
+
+class DConfigManager;
+class DConfigManagerPrivate
+{
+    friend class DConfigManager;
+    DConfigManager *q { nullptr };
+
+    QMap<QString, DTK_NAMESPACE::DCORE_NAMESPACE::DConfig *> configs;
+    QReadWriteLock lock;
+
+public:
+    explicit DConfigManagerPrivate(DConfigManager *qq)
+        : q(qq) {}
+};
+
+#endif   // DCONFIGMANAGER_P_H


### PR DESCRIPTION
fix: On some device models, using GPU acceleration causes crashes.

On some device models, using GPU acceleration during the OCR process leads to crashes during destruction. Now, the os-config solution is employed to customize these machines.

fix: 某些机型上，使用GPU加速导致崩溃

在某些机型上，OCR过程中使用GPU加速，析构时会导致崩溃。现在使用os-config方案对这些机器进行定制。