### PR TITLE
fix: Process crash caused by closing the application.

### DIFF
--- a/src/mainwidget.cpp
+++ b/src/mainwidget.cpp
@@ -50,6 +50,17 @@ MainWidget::~MainWidget()
 {
     //程序即将结束,线程标志结束
     m_isEndThread = 0;
+    // 等待线程结束
+    if (m_loadImagethread) {
+        m_loadImagethread->requestInterruption(); // 请求线程中断
+        if (!m_loadImagethread->wait(3000)) { // 等待线程结束，超时时间为3秒
+            qWarning() << "OCR thread TIMEOUT";
+            m_loadImagethread->terminate(); // 如果线程没有结束，强制终止线程
+            m_loadImagethread->deleteLater(); // 删除线程对象
+            m_loadImagethread = nullptr;
+        }
+        // 正常结束的情况下delete操作在槽函数中执行
+    }
 }
 
 void MainWidget::setupUi(QWidget *Widget)


### PR DESCRIPTION
When performing the destruction operation, it is necessary to wait for the child thread to exit to avoid errors in resource release.

fix: 关闭应用引起进程崩溃

析构操作时，需要等待子线程退出，避免资源释放出错。

Bug: https://pms.uniontech.com/bug-view-334545.html （参考v20）