### PR TITLE
build(cmake): refactor Qt version compatibility

### DIFF
--- a/debian/control.1
+++ b/debian/control.1
@@ -5,14 +5,14 @@ Maintainer: Deepin Packages Builder <packages@deepin.com>
 Build-Depends: debhelper (>= 11),
  cmake,
  pkg-config,
- qt6-base-dev,
- qt6-tools-dev,
- qt6-tools-dev-tools,
- libdtk6widget-dev,
- libdtk6core-dev,
+ qtbase5-dev,
+ qttools5-dev,
+ qttools5-dev-tools,
+ libdtkwidget-dev,
+ libdtkcore-dev,
  libncnn-dev,
  libopencv-mobile-dev,
- libdtk6ocr-dev
+ libdtkocr-dev
 Standards-Version: 4.1.3
 Homepage: http://www.deepin.org/
 

--- a/debian/rules
+++ b/debian/rules
@@ -1,12 +1,31 @@
 #!/usr/bin/make -f
+include /usr/share/dpkg/default.mk
 
 export QT_SELECT=5
-include /usr/share/dpkg/default.mk
+
+# 检测当前安装的Qt版本，优先使用Qt6，否则使用Qt5
+define detect_qt_version
+ifneq (,$(shell which qmake6 2>/dev/null))
+    QT_DIR="/usr/lib/$(DEB_HOST_MULTIARCH)/cmake/Qt6"
+else
+    QT_DIR="/usr/lib/$(DEB_HOST_MULTIARCH)/cmake/Qt5"
+endif
+endef
+
+# 调用检测Qt版本的命令
+$(eval $(call detect_qt_version))
+
+# hardcode this if want to force build with sepecific Qt version
+# QT_DIR="/usr/lib/$(DEB_HOST_MULTIARCH)/cmake/Qt5"
+
+DH_AUTO_ARGS = --parallel --buildsystem=cmake
 
 %:
 	dh $@
 
-
 override_dh_auto_configure:
-	dh_auto_configure -- VERSION=$(VERSION) LIB_INSTALL_DIR=/usr/lib/$(DEB_HOST_MULTIARCH) DEFINES+="VERSION=$(DEB_VERSION_UPSTREAM)"
-
+	dh_auto_configure -- \
+	-DCMAKE_BUILD_TYPE=Release \
+	-DVERSION=$(DEB_VERSION_UPSTREAM) \
+	-DCMAKE_INSTALL_LIBDIR=/usr/lib/$(DEB_HOST_MULTIARCH) \
+	-DQT_DIR=$(QT_DIR)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,18 +8,20 @@ project(deepin-ocr)
 #玲珑构建依赖目录
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
 
-set(ENABLE_Qt6 ON CACHE BOOL "Build with Qt6")
-find_package(Qt6 QUIET)
+# Auto-detect Qt version (tries Qt6 first, falls back to Qt5)
+find_package(QT NAMES Qt6 Qt5 REQUIRED COMPONENTS Core)
 
-if(ENABLE_Qt6 AND Qt6_FOUND)
+# Map to DTK version (Qt6→DTK6, Qt5→DTK5)
+if (QT_VERSION_MAJOR MATCHES 6)
     set(DTK_VERSION_MAJOR 6)
-    set(QT_VERSION_MAJOR 6)
     set(SUPPORT_QT6 TRUE)
 else()
-    set(QT_VERSION_MAJOR 5)
+    set(DTK_VERSION_MAJOR "")
+    set(SUPPORT_QT6 FALSE)
 endif()
 
-message(STATUS "--- Current Qt verison: ${QT_VERSION_MAJOR}")
+message(STATUS "Found Qt version: ${QT_VERSION_MAJOR}")
+message(STATUS "Build with DTK: ${DTK_VERSION_MAJOR}")
 
 # 玲珑构建依赖目录
 include_directories(${CMAKE_INSTALL_PREFIX}/include)
@@ -171,13 +173,6 @@ endif()
 pkg_check_modules(InferenceEngine REQUIRED ncnn opencv_mobile)
 target_include_directories(${PROJECT_NAME} PUBLIC ${ocr_lib_INCLUDE_DIRS})
 find_package(Dtk${DTK_VERSION_MAJOR} REQUIRED COMPONENTS Core Widget)
-if(NOT SUPPORT_QT6)
-    qt5_use_modules(${PROJECT_NAME} ${QtModule})
-endif()
-
-if(DOTEST AND NOT SUPPORT_QT6)
-    qt5_use_modules(${PROJECT_NAME_TEST} ${QtModule})
-endif()
 
 target_link_libraries(${PROJECT_NAME}
     Qt${QT_VERSION_MAJOR}::Core


### PR DESCRIPTION
- Add Qt auto-detection using find_package(QT NAMES Qt6 Qt5)
- Separate debian/control files:
  * control: V25 (Qt6) with explicit qt6-base-dev, libdtk6*-dev deps
  * control.1: V20 (Qt5) with explicit qtbase5-dev, libdtk*-dev deps

This enables seamless building on both V25 (Qt6) and V20 (Qt5) systems without version-specific conditional dependencies.

Log: 分离Qt5/Qt6构建配置，支持V25/V20双版本
PMS: https://pms.uniontech.com/task-view-386321.html