### PR TITLE
test: migrate unit tests from Qt5 to Qt6 compatibility

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -118,8 +118,9 @@ if(DOTEST)
     aux_source_directory(./../tests/ allTestSource)
     aux_source_directory(./view allTestSource)
     aux_source_directory(./service allTestSource)
-    aux_source_directory(./paddleocr-ncnn allTestSource)
-    aux_source_directory(../3rdparty/clipper allTestSource)
+    aux_source_directory(./engine allTestSource)
+    aux_source_directory(./util allTestSource)
+    aux_source_directory(./utils allTestSource)
 
     FILE(GLOB allTestSource1
         "./frame.cpp"
@@ -186,13 +187,18 @@ target_link_libraries(${PROJECT_NAME}
 )
 
 if(DOTEST)
+    target_include_directories(${PROJECT_NAME_TEST} PUBLIC ${ocr_lib_INCLUDE_DIRS})
+    target_include_directories(${PROJECT_NAME_TEST} PUBLIC ${InferenceEngine_INCLUDE_DIRS})
     target_link_libraries(${PROJECT_NAME_TEST}
         Qt${QT_VERSION_MAJOR}::Core
         Qt${QT_VERSION_MAJOR}::Gui
         Qt${QT_VERSION_MAJOR}::Widgets
+        Qt${QT_VERSION_MAJOR}::Test
+        Qt${QT_VERSION_MAJOR}::DBus
         Dtk${DTK_VERSION_MAJOR}::Core
         Dtk${DTK_VERSION_MAJOR}::Widget
         ${ocr_lib_LIBRARIES}
+        ${InferenceEngine_LIBRARIES}
         pthread
     )
 endif()

--- a/src/mainwidget.cpp
+++ b/src/mainwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -287,7 +287,8 @@ void MainWidget::setupUi(QWidget *Widget)
     pLay->addWidget(undoBtn);
     pLay->addSpacing(10);
     pLay->addWidget(redoBtn);
-    mainWindow->titlebar()->addWidget(pWidget, Qt::AlignRight);
+    if (mainWindow)
+        mainWindow->titlebar()->addWidget(pWidget, Qt::AlignRight);
 
     if (DGuiApplicationHelper::instance()->sizeMode() == DGuiApplicationHelper::CompactMode) {
         languageSelectBox->setFixedSize(160, 24);
@@ -315,7 +316,8 @@ void MainWidget::setupUi(QWidget *Widget)
     //占位用空白控件
     m_emptyWidget = new QWidget;
     m_emptyWidget->setMinimumSize(36 * 2, 36 * 2);
-    mainWindow->titlebar()->addWidget(m_emptyWidget, Qt::AlignRight);
+    if (mainWindow)
+        mainWindow->titlebar()->addWidget(m_emptyWidget, Qt::AlignRight);
 }
 
 void MainWidget::setupConnect()

--- a/tests/test_mainwindow.cpp
+++ b/tests/test_mainwindow.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@
 #define protected public
 
 #include "ocrapplication.h"
+#include "engine/OCREngine.h"
 #include "mainwidget.h"
 #include "view/imageview.h"
 //初始拉起主界面
@@ -32,7 +33,7 @@ TEST(MainWindow, mainwindow_openFile)
     instance.openFile(picPath);
     bool bRet = false;
     while (!bRet) {
-        if (!PaddleOCRApp::instance()->isRunning()) {
+        if (!OCREngine::instance()->isRunning()) {
             bRet = true;
             QTest::qWait(1000);
         }
@@ -42,7 +43,7 @@ TEST(MainWindow, mainwindow_openFile)
 
     bRet = false;
     while (!bRet) {
-        if (!PaddleOCRApp::instance()->isRunning()) {
+        if (!OCREngine::instance()->isRunning()) {
             bRet = true;
             QTest::qWait(1000);
         }

--- a/tests/test_qtestmain.cpp
+++ b/tests/test_qtestmain.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -25,20 +25,13 @@ using namespace Dtk::Core;
 using namespace Dtk::Widget;
 
 #define QMYTEST_MAIN(TestObject) \
-    QT_BEGIN_NAMESPACE \
-    QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS \
-    QT_END_NAMESPACE \
     int main(int argc, char *argv[]) \
     { \
         DApplication *dAppNew = new DApplication(argc, argv); \
-        dAppNew->setAttribute(Qt::AA_UseHighDpiPixmaps); \
         dAppNew->setOrganizationName("deepin"); \
         dAppNew->setApplicationName("deepin-ocr"); \
         dAppNew->loadTranslator(QList<QLocale>() << QLocale::system()); \
-        QTEST_DISABLE_KEYPAD_NAVIGATION \
-        QTEST_ADD_GPU_BLACKLIST_SUPPORT \
         TestObject tc; \
-        QTEST_SET_MAIN_SOURCE_PATH \
         return QTest::qExec(&tc, argc, argv); \
     } \
 

--- a/tests/test_resulttextview.cpp
+++ b/tests/test_resulttextview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -13,6 +13,7 @@
 #include <QGesture>
 #include <QTapAndHoldGesture>
 #include <QMenu>
+#include <QtGlobal>
 
 #define private public
 #define protected public
@@ -61,7 +62,11 @@ TEST(ResultTextView, mainwindow)
         QResizeEvent resizeEvent(QSize(500, 200), QSize(500, 400));
         reTextView->resizeEvent(&resizeEvent);
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QMouseEvent *ev = new QMouseEvent(QEvent::MouseMove, QPoint(15,36), QPoint(25,40), QPoint(60,80), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
         QMouseEvent *ev = new QMouseEvent(QEvent::MouseMove, QPoint(15,36), QPoint(25,40), QPoint(60,80), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier, Qt::MouseEventSynthesizedByQt);
+#endif
         reTextView->m_gestureAction = ResultTextView::GA_slide;
         reTextView->mouseMoveEvent(ev);
         delete ev;
@@ -72,11 +77,19 @@ TEST(ResultTextView, mainwindow)
         reTextView->contextMenuEvent(nullptr);
         stub.reset((QAction*(QMenu::*)(const QPoint &, QAction *))ADDR(QMenu, exec));
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QMouseEvent *evPress = new QMouseEvent(QEvent::MouseButtonPress, QPoint(15,36), QPoint(25,40), QPoint(60,80), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
         QMouseEvent *evPress = new QMouseEvent(QEvent::MouseButtonPress, QPoint(15,36), QPoint(25,40), QPoint(60,80), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier, Qt::MouseEventSynthesizedByQt);
+#endif
         reTextView->mousePressEvent(evPress);
         delete evPress;
 
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+        QMouseEvent *evRele = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(15,36), QPoint(25,40), QPoint(60,80), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier);
+#else
         QMouseEvent *evRele = new QMouseEvent(QEvent::MouseButtonRelease, QPoint(15,36), QPoint(25,40), QPoint(60,80), Qt::LeftButton, Qt::LeftButton, Qt::NoModifier, Qt::MouseEventSynthesizedByQt);
+#endif
         reTextView->mouseReleaseEvent(evRele);
         delete evRele;
 


### PR DESCRIPTION
- Remove Qt::AA_UseHighDpiPixmaps (removed in Qt6)
- Remove QTEST_ADD_GPU_BLACKLIST_SUPPORT_DEFS (removed in Qt6 QTest)
- Add QT_VERSION_CHECK guards for QMouseEvent constructor changes
- Replace obsolete PaddleOCRApp with OCREngine
- Fix CMakeLists.txt: add missing source dirs, link Qt::Test/DBus
- Fix mainWindow null pointer crash in MainWidget::setupUi

- 移除Qt6中已删除的AA_UseHighDpiPixmaps和GPU黑名单宏
- 添加QMouseEvent构造函数Qt5/Qt6版本条件编译
- 替换已废弃的PaddleOCRApp为OCREngine
- 修复CMakeLists.txt缺少的源目录和链接库
- 修复MainWidget::setupUi中mainWindow空指针崩溃

Log: 单元测试迁移Qt6兼容并修复相关编译和运行问题
Influence: 单元测试可在Qt6环境下正常编译运行，修复源码中一处潜在的空指针崩溃