### PR TITLE
fix: use DTK standard TextTips color and T7 font for tip label

### DIFF
--- a/src/mainwidget.cpp
+++ b/src/mainwidget.cpp
@@ -30,6 +30,7 @@
 #include <DFloatingWidget>
 #include <DAnchors>
 #include <DFontSizeManager>
+#include <DPalette>
 #include <DHiDPIHelper>
 #include <DDciIcon>
 #include <QSettings>
@@ -161,6 +162,14 @@ void MainWidget::setupUi(QWidget *Widget)
 
     m_tiplabel = new DLabel(Widget);
     m_tiplabel->setObjectName(QStringLiteral("tiplabel"));
+    // 提示文字使用 DTK 标准的辅助提示字号与颜色，随主题统一刷新
+    DFontSizeManager::instance()->bind(m_tiplabel, DFontSizeManager::T7);
+    {
+        DPalette dp = DGuiApplicationHelper::instance()->applicationPalette();
+        QPalette pe;
+        pe.setColor(QPalette::WindowText, dp.color(DPalette::TextTips));
+        m_tiplabel->setPalette(pe);
+    }
 
     m_tipHorizontalLayout->setSpacing(4);
     m_tipHorizontalLayout->addWidget(m_tiplabel);
@@ -720,8 +729,9 @@ void MainWidget::setIcons(DGuiApplicationHelper::ColorType themeType)
             m_frame->setPalette(pal);
         }
         if (m_tiplabel) {
+            DPalette dp = DGuiApplicationHelper::instance()->applicationPalette();
             QPalette pe;
-            pe.setColor(QPalette::WindowText, QColor(109, 124, 136));
+            pe.setColor(QPalette::WindowText, dp.color(DPalette::TextTips));
             m_tiplabel->setPalette(pe);
         }
         if (m_noResult) {
@@ -775,8 +785,9 @@ void MainWidget::setIcons(DGuiApplicationHelper::ColorType themeType)
             m_frame->setPalette(pal);
         }
         if (m_tiplabel) {
+            DPalette dp = DGuiApplicationHelper::instance()->applicationPalette();
             QPalette pe;
-            pe.setColor(QPalette::WindowText, QColor(138, 161, 180));
+            pe.setColor(QPalette::WindowText, dp.color(DPalette::TextTips));
             m_tiplabel->setPalette(pe);
         }
         if (m_noResult) {


### PR DESCRIPTION
fix(tiplabel): use DTK TextTips color and T7 font
1. Replace hardcoded tip label colors (109,124,136 / 138,161,180) with DPalette::TextTips so the label follows the theme palette
2. Bind the tip label font to DFontSizeManager::T7 for consistent auxiliary tip sizing
3. Apply TextTips color in both light and dark setIcons branches to keep them in sync
4. Add the DPalette include for the new palette usage

Log: Use DTK standard TextTips color and T7 font for the tip label so it tracks theme palette changes

fix(tiplabel): 使用 DTK 标准 TextTips 颜色与 T7 字号

1. 将提示标签硬编码颜色(109,124,136 / 138,161,180)替换为 DPalette::TextTips,使其随主题调色板统一变化
2. 将提示标签字体绑定到 DFontSizeManager::T7,保证辅助提示字号一致
3. 在 setIcons 的亮色与暗色分支均使用 TextTips 颜色,保持两套主题一致
4. 新增 DPalette 头文件以支持调色板取色

Log: 使用 DTK 标准 TextTips 颜色与 T7 字号,让提示文字随主题调色板统一刷新
PMS: BUG-368759