### PR TITLE
fix: remove deepin prefix from Chinese translations in desktop file

### DIFF
--- a/deepin-ocr.desktop
+++ b/deepin-ocr.desktop
@@ -24,5 +24,5 @@ GenericName[zh_TW]=圖文識別工具
 
 Name[lo]=Deepin ຈົດຈຳຕົວອັກສອນ
 Name[zh_CN]=图文识别工具
-Name[zh_HK]=Deepin 圖文識別工具
-Name[zh_TW]=Deepin 圖文識別工具
+Name[zh_HK]=圖文識別工具
+Name[zh_TW]=圖文識別工具


### PR DESCRIPTION
Remove "深度"/"deepin"/"Deepin" prefix from Name/Comment fields in zh_CN, zh_HK, zh_TW translations.

去除 desktop 文件中 zh_CN/zh_HK/zh_TW 翻译的"深度"/"deepin"前缀。

Log: 去除desktop文件中文翻译中的深度/deepin前缀
PMS: BUG-369185
Influence: 自研应用 desktop 文件中文翻译不再包含"深度"/"deepin"品牌前缀。

## Summary by Sourcery

Bug Fixes:
- Correct Chinese desktop entry translations by eliminating redundant Deepin/“深度” prefixes from Name and Comment fields.