### PR TITLE
fix: add X-Deepin-Singleton flag to desktop file (#392841)

### DIFF
--- a/deepin-ocr.desktop
+++ b/deepin-ocr.desktop
@@ -10,6 +10,7 @@ NoDisplay=true
 X-Deepin-ManualID=deepin-ocr
 X-Deepin-Vendor=deepin
 X-Deepin-TurboType=dtkwidget
+X-Deepin-Singleton=true
 
 # Translations:
 # Do not manually modify!


### PR DESCRIPTION
Add X-Deepin-Singleton=true to desktop file to mark the application as a singleton app. This allows AM to identify singleton apps and inform Treeland to skip the splash screen for these apps.

Refs: https://pms.uniontech.com/task-view-392841.html

## Summary by Sourcery

Enhancements:
- Add the X-Deepin-Singleton=true flag to the deepin-ocr desktop entry to identify it as a singleton application.