### PR TITLE
feat: enhance OCR text extraction with char-level selection and linkage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ debian/deepin-image-viewer.substvars
 !debian/control
 !debian/compat
 !debian/source/*
+
+#AI tools
+.npm-cache
+.specstory
+.cursor
+.codegraph

--- a/src/engine/OCREngine.cpp
+++ b/src/engine/OCREngine.cpp
@@ -1,8 +1,9 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #include "OCREngine.h"
+#include "OcrResult.h"
 #include <DOcr>
 #include <QProcess>
 #include <QFileInfo>
@@ -75,13 +76,13 @@ void OCREngine::setImage(const QImage &image)
     ocrDriver->setImage(image);
 }
 
-QString OCREngine::getRecogitionResult()
+OcrResult OCREngine::getRecognitionResult()
 {
     qCInfo(dmOcr) << "Starting OCR recognition";
     m_isRunning = true;
 
     ocrDriver->analyze();
-    QString result = ocrDriver->simpleResult();
+    OcrResult result = OcrResult::fromDOcr(ocrDriver);
     m_isRunning = false;
     qCInfo(dmOcr) << "OCR recognition completed";
     return result;

--- a/src/engine/OCREngine.h
+++ b/src/engine/OCREngine.h
@@ -1,8 +1,10 @@
-// SPDX-FileCopyrightText: 2023 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2023-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
 #pragma once
+
+#include "OcrResult.h"
 
 #include <atomic>
 #include <QImage>
@@ -33,7 +35,7 @@ public:
 
     bool setLanguage(const QString &language);
     void setImage(const QImage &image);
-    QString getRecogitionResult();
+    OcrResult getRecognitionResult();
 
 private:
     OCREngine();

--- a/src/engine/OcrResult.cpp
+++ b/src/engine/OcrResult.cpp
@@ -1,0 +1,390 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#include "OcrResult.h"
+
+#include <DOcr>
+#include <docr.h>
+
+#include <QtMath>
+#include <QLineF>
+#include <QVector>
+#include <algorithm>
+
+namespace {
+
+QRectF boxRect(const Dtk::Ocr::TextBox &box)
+{
+    if (box.points.size() < 4) {
+        return {};
+    }
+
+    qreal minX = box.points.first().x();
+    qreal maxX = minX;
+    qreal minY = box.points.first().y();
+    qreal maxY = minY;
+    for (const auto &point : box.points) {
+        minX = qMin(minX, point.x());
+        maxX = qMax(maxX, point.x());
+        minY = qMin(minY, point.y());
+        maxY = qMax(maxY, point.y());
+    }
+    return QRectF(minX, minY, maxX - minX, maxY - minY);
+}
+
+qreal centerY(const QRectF &rect)
+{
+    return rect.center().y();
+}
+
+qreal centerX(const QRectF &rect)
+{
+    return rect.center().x();
+}
+
+qreal characterDisplayWeight(QChar ch)
+{
+    const ushort unicode = ch.unicode();
+    if (unicode <= 0x007F) {
+        return 1.0;
+    }
+    if (unicode >= 0xFF01 && unicode <= 0xFF60) {
+        return 1.0;
+    }
+    return 2.0;
+}
+
+QList<OcrCharItem> buildCharItems(const OcrLineItem &line, int lineIndex, const QList<Dtk::Ocr::TextBox> &charBoxes)
+{
+    QList<OcrCharItem> chars;
+    if (line.text.isEmpty()) {
+        return chars;
+    }
+
+    const QRectF lineRect = line.rect;
+    const int textLen = line.text.size();
+    chars.reserve(textLen);
+
+    const bool useRealBoxes = (charBoxes.size() == textLen);
+
+    // Equal-length fast path: each recognized char already has its real
+    // polygon from the engine — use it verbatim so highlight/click positions
+    // align with the actual glyphs in the image (V-2325 v7 problem 1). Only
+    // when the counts mismatch do we fall back to weight-based synthesis,
+    // distributing the line rect across the chars proportionally. Each char's
+    // bounding rect is precomputed and cached in OcrCharItem::rect so the hot
+    // paths (draw/lasso/click) never recompute it (V-2325 v8 perf).
+    if (useRealBoxes) {
+        for (int charIndex = 0; charIndex < textLen; ++charIndex) {
+            OcrCharItem item;
+            item.box = charBoxes.at(charIndex);
+            item.rect = OcrResult::textBoxRect(item.box);
+            item.lineIndex = lineIndex;
+            item.charIndexInLine = charIndex;
+            item.character = line.text.at(charIndex);
+            chars.append(item);
+        }
+        return chars;
+    }
+
+    QVector<qreal> weights(textLen);
+    qreal totalWeight = 0.0;
+    for (int charIndex = 0; charIndex < textLen; ++charIndex) {
+        weights[charIndex] = characterDisplayWeight(line.text.at(charIndex));
+        totalWeight += weights[charIndex];
+    }
+    if (totalWeight <= 0.0) {
+        totalWeight = textLen;
+        weights.fill(1.0, textLen);
+    }
+
+    qreal x = lineRect.left();
+    for (int charIndex = 0; charIndex < textLen; ++charIndex) {
+        const qreal charWidth = lineRect.width() * weights.at(charIndex) / totalWeight;
+        OcrCharItem item;
+        Dtk::Ocr::TextBox box;
+        box.angle = 0;
+        box.points.push_back(QPointF(x, lineRect.top()));
+        box.points.push_back(QPointF(x + charWidth, lineRect.top()));
+        box.points.push_back(QPointF(x + charWidth, lineRect.bottom()));
+        box.points.push_back(QPointF(x, lineRect.bottom()));
+        item.box = box;
+        item.rect = QRectF(x, lineRect.top(), charWidth, lineRect.height());
+        item.lineIndex = lineIndex;
+        item.charIndexInLine = charIndex;
+        item.character = line.text.at(charIndex);
+        chars.append(item);
+        x += charWidth;
+    }
+    return chars;
+}
+
+QList<QList<int>> groupIntoVisualLines(QList<OcrLineItem> &rawLines)
+{
+    QList<int> order;
+    order.reserve(rawLines.size());
+    for (int i = 0; i < rawLines.size(); ++i) {
+        order.append(i);
+    }
+
+    std::sort(order.begin(), order.end(), [&rawLines](int a, int b) {
+        const QRectF rectA = rawLines[a].rect;
+        const QRectF rectB = rawLines[b].rect;
+        const qreal ya = centerY(rectA);
+        const qreal yb = centerY(rectB);
+        if (qAbs(ya - yb) > 4.0) {
+            return ya < yb;
+        }
+        return centerX(rectA) < centerX(rectB);
+    });
+
+    QList<QList<int>> groups;
+    for (int index : order) {
+        const QRectF rect = rawLines[index].rect;
+        const qreal cy = centerY(rect);
+        const qreal height = rect.height();
+
+        int targetGroup = -1;
+        for (int groupIndex = 0; groupIndex < groups.size(); ++groupIndex) {
+            const int rep = groups[groupIndex].constFirst();
+            const QRectF repRect = rawLines[rep].rect;
+            if (qAbs(cy - centerY(repRect)) < qMin(height, repRect.height()) * 0.55) {
+                targetGroup = groupIndex;
+                break;
+            }
+        }
+
+        if (targetGroup < 0) {
+            groups.append(QList<int>{index});
+        } else {
+            groups[targetGroup].append(index);
+        }
+    }
+
+    for (auto &group : groups) {
+        std::sort(group.begin(), group.end(), [&rawLines](int a, int b) {
+            return centerX(rawLines[a].rect) < centerX(rawLines[b].rect);
+        });
+    }
+
+    std::sort(groups.begin(), groups.end(), [&rawLines](const QList<int> &a, const QList<int> &b) {
+        return centerY(rawLines[a.constFirst()].rect) < centerY(rawLines[b.constFirst()].rect);
+    });
+
+    return groups;
+}
+
+bool needSpaceBetweenBoxes(const OcrLineItem &previous, const OcrLineItem &current)
+{
+    const QRectF prevRect = previous.rect;
+    const QRectF currRect = current.rect;
+    const qreal gap = currRect.left() - prevRect.right();
+    const qreal threshold = qMin(prevRect.height(), currRect.height()) * 0.35;
+    return gap > threshold;
+}
+
+} // namespace
+
+QRectF OcrResult::textBoxRect(const Dtk::Ocr::TextBox &box)
+{
+    return boxRect(box);
+}
+
+bool OcrResult::textBoxContains(const Dtk::Ocr::TextBox &box, const QPointF &point)
+{
+    return boxRect(box).contains(point);
+}
+
+OcrResult OcrResult::fromDOcr(Dtk::Ocr::DOcr *ocr)
+{
+    OcrResult result;
+    if (ocr == nullptr) {
+        return result;
+    }
+
+    const auto textBoxes = ocr->textBoxes();
+    if (textBoxes.isEmpty()) {
+        return result;
+    }
+
+    QList<OcrLineItem> rawLines;
+    rawLines.reserve(textBoxes.size());
+    for (int i = 0; i < textBoxes.size(); ++i) {
+        OcrLineItem line;
+        line.box = textBoxes.at(i);
+        line.rect = textBoxRect(line.box);  // precompute once (V-2325 v8 perf)
+        line.text = ocr->resultFromBox(i);
+        if (line.text.isEmpty()) {
+            continue;
+        }
+        line.chars = buildCharItems(line, rawLines.size(), ocr->charBoxes(i));
+        rawLines.append(line);
+    }
+
+    const auto visualLines = groupIntoVisualLines(rawLines);
+    int offset = 0;
+    for (int visualIndex = 0; visualIndex < visualLines.size(); ++visualIndex) {
+        const auto &group = visualLines.at(visualIndex);
+        if (visualIndex > 0) {
+            result.plainText.append('\n');
+            ++offset;
+        }
+
+        for (int boxIndex = 0; boxIndex < group.size(); ++boxIndex) {
+            const int rawIndex = group.at(boxIndex);
+            auto &line = rawLines[rawIndex];
+
+            if (boxIndex > 0) {
+                const int prevRawIndex = group.at(boxIndex - 1);
+                if (needSpaceBetweenBoxes(rawLines[prevRawIndex], line)) {
+                    result.plainText.append(' ');
+                    ++offset;
+                }
+            }
+
+            line.plainTextStart = offset;
+            result.plainText.append(line.text);
+            offset += line.text.size();
+            line.plainTextEnd = offset;
+
+            for (auto &item : line.chars) {
+                item.plainTextStart = line.plainTextStart + item.charIndexInLine;
+                item.plainTextEnd = item.plainTextStart + 1;
+                item.lineIndex = result.lines.size();
+                result.allChars.append(item);
+            }
+            result.lines.append(line);
+        }
+    }
+
+    return result;
+}
+
+int OcrResult::charIndexAt(const QPointF &imagePos) const
+{
+    // Strict hit-only (V-2325 v5/v7): a char is selected only when the click
+    // point truly falls inside its box. Space/tab synthesized boxes are never
+    // click targets (isSpace() skip), so clicking inter-word gaps returns -1
+    // and the view clears the selection — no nearest-line/nearest-char snapping.
+    for (int i = 0; i < allChars.size(); ++i) {
+        const OcrCharItem &ch = allChars.at(i);
+        if (ch.character.isSpace()) {
+            continue;
+        }
+        if (ch.rect.contains(imagePos)) {
+            return i;
+        }
+    }
+    return -1;
+}
+
+QList<QPair<int, int>> OcrResult::plainTextRangesForRect(const QRectF &rect) const
+{
+    if (rect.isNull() || rect.isEmpty()) {
+        return {};
+    }
+
+    QList<int> hitIndices;
+    hitIndices.reserve(allChars.size());
+    for (int i = 0; i < allChars.size(); ++i) {
+        if (rect.intersects(allChars.at(i).rect)) {
+            hitIndices.append(i);
+        }
+    }
+
+    if (hitIndices.isEmpty()) {
+        return {};
+    }
+
+    std::sort(hitIndices.begin(), hitIndices.end());
+
+    QList<QPair<int, int>> ranges;
+    int rangeStart = allChars.at(hitIndices.first()).plainTextStart;
+    int rangeEnd = allChars.at(hitIndices.first()).plainTextEnd;
+    int prevCharIndex = hitIndices.first();
+
+    for (int k = 1; k < hitIndices.size(); ++k) {
+        const int idx = hitIndices.at(k);
+        const auto &item = allChars.at(idx);
+        if (idx == prevCharIndex + 1) {
+            rangeEnd = item.plainTextEnd;
+        } else {
+            ranges.append(qMakePair(rangeStart, rangeEnd));
+            rangeStart = item.plainTextStart;
+            rangeEnd = item.plainTextEnd;
+        }
+        prevCharIndex = idx;
+    }
+    ranges.append(qMakePair(rangeStart, rangeEnd));
+    return ranges;
+}
+
+QString OcrResult::textInRanges(const QList<QPair<int, int>> &ranges) const
+{
+    QString result;
+    for (const auto &range : ranges) {
+        result.append(textInRange(range.first, range.second));
+    }
+    return result;
+}
+
+QString OcrResult::textInRange(int start, int end) const
+{
+    if (start < 0 || end <= start || start >= plainText.size()) {
+        return {};
+    }
+    return plainText.mid(start, qMin(end, plainText.size()) - start);
+}
+
+QList<int> OcrResult::charIndicesInRange(int start, int end) const
+{
+    QList<int> indices;
+    for (int i = 0; i < allChars.size(); ++i) {
+        const auto &item = allChars.at(i);
+        if (item.plainTextEnd <= start || item.plainTextStart >= end) {
+            continue;
+        }
+        indices.append(i);
+    }
+    return indices;
+}
+
+QList<QRectF> OcrResult::highlightRects(int start, int end) const
+{
+    QList<QRectF> rects;
+    if (start < 0 || end <= start) {
+        return rects;
+    }
+
+    for (const auto &line : lines) {
+        if (line.plainTextEnd <= start || line.plainTextStart >= end) {
+            continue;
+        }
+
+        QRectF united;
+        for (const auto &item : line.chars) {
+            if (item.plainTextEnd <= start || item.plainTextStart >= end) {
+                continue;
+            }
+            united = united.isNull() ? item.rect : united.united(item.rect);
+        }
+
+        if (united.isNull()) {
+            united = line.rect;
+        }
+        if (!united.isNull()) {
+            rects.append(united);
+        }
+    }
+    return rects;
+}
+
+QList<QRectF> OcrResult::highlightRectsForRanges(const QList<QPair<int, int>> &ranges) const
+{
+    QList<QRectF> rects;
+    for (const auto &range : ranges) {
+        rects.append(highlightRects(range.first, range.second));
+    }
+    return rects;
+}

--- a/src/engine/OcrResult.h
+++ b/src/engine/OcrResult.h
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+#pragma once
+
+#include <docr.h>
+
+#include <QChar>
+#include <QList>
+#include <QPointF>
+#include <QRectF>
+#include <QString>
+
+namespace Dtk {
+namespace Ocr {
+class DOcr;
+}
+}
+
+struct OcrCharItem
+{
+    Dtk::Ocr::TextBox box;
+    QRectF rect;                 // Cached bounding rect of #box (V-2325 v8 perf).
+    int lineIndex = -1;
+    int charIndexInLine = -1;
+    QChar character;
+    int plainTextStart = -1;
+    int plainTextEnd = -1;
+};
+
+struct OcrLineItem
+{
+    Dtk::Ocr::TextBox box;
+    QRectF rect;                 // Cached bounding rect of #box (V-2325 v8 perf).
+    QString text;
+    int plainTextStart = -1;
+    int plainTextEnd = -1;
+    QList<OcrCharItem> chars;
+};
+
+struct OcrResult
+{
+    QString plainText;
+    QList<OcrLineItem> lines;
+    QList<OcrCharItem> allChars;
+
+    bool isEmpty() const
+    {
+        return lines.isEmpty();
+    }
+
+    static OcrResult fromDOcr(Dtk::Ocr::DOcr *ocr);
+
+    int charIndexAt(const QPointF &imagePos) const;
+    QString textInRange(int start, int end) const;
+    QString textInRanges(const QList<QPair<int, int>> &ranges) const;
+    QList<QPair<int, int>> plainTextRangesForRect(const QRectF &rect) const;
+    QList<int> charIndicesInRange(int start, int end) const;
+    QList<QRectF> highlightRects(int start, int end) const;
+    QList<QRectF> highlightRectsForRanges(const QList<QPair<int, int>> &ranges) const;
+
+    static QRectF textBoxRect(const Dtk::Ocr::TextBox &box);
+    static bool textBoxContains(const Dtk::Ocr::TextBox &box, const QPointF &point);
+};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,9 @@
 #include <QDBusConnection>
 #include <QDBusInterface>
 #include "util/log.h"
+#include "engine/OcrResult.h"
+
+#include <QMetaType>
 
 DWIDGET_USE_NAMESPACE
 
@@ -42,6 +45,8 @@ int main(int argc, char *argv[])
     app->setApplicationName("deepin-ocr");
     app->setProductName(QObject::tr("OCR Tool"));
     app->setApplicationVersion("1.0");
+
+    qRegisterMetaType<OcrResult>("OcrResult");
 
     qCInfo(dmOcr) << "Starting Deepin OCR Tool version 1.0";
 

--- a/src/mainwidget.cpp
+++ b/src/mainwidget.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 - 2026 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,8 @@
 #include <QTimer>
 #include <QShortcut>
 #include <QPushButton>
+#include <QClipboard>
+#include <QGuiApplication>
 
 #include <DGuiApplicationHelper>
 #include <DMainWindow>
@@ -337,8 +339,14 @@ void MainWidget::setupConnect()
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::paletteTypeChanged, this, &MainWidget::setIcons);
     connect(m_exportBtn, &DIconButton::clicked, this, &MainWidget::slotExport);
     connect(m_copyBtn, &DIconButton::clicked, this, &MainWidget::slotCopy);
-    connect(this, &MainWidget::sigResult, this, [ = ](const QString & result) {
-        loadString(result);
+    connect(m_imageview, &ImageView::selectionRangesChanged, this, &MainWidget::syncSelectionFromImage);
+    connect(m_imageview, &ImageView::copyRequested, this, &MainWidget::copyCurrentSelection);
+    connect(m_plainTextEdit, &ResultTextView::textSelectionChanged, this, &MainWidget::syncSelectionFromText);
+    connect(m_plainTextEdit, &ResultTextView::textSelectionChanged, this, &MainWidget::updateCopyActionState);
+    connect(m_plainTextEdit, &QPlainTextEdit::selectionChanged, this, &MainWidget::updateCopyActionState);
+    connect(m_imageview, &ImageView::selectionRangesChanged, this, &MainWidget::updateCopyActionState);
+    connect(this, &MainWidget::sigResult, this, [ = ](const OcrResult &result) {
+        applyOcrResult(result);
         deleteLoadingUi();
         if(m_needReRunRec) {
             m_needReRunRec = false;
@@ -416,7 +424,11 @@ void MainWidget::loadingUi()
 
 void MainWidget::initShortcut()
 {
-    m_scAddView = new QShortcut(QKeySequence("Ctrl+="), this);
+    // V-2325 v4: Ctrl'+' (QKeySequence::ZoomIn) + Ctrl '=' double binding so
+    // both Ctrl'+' and Ctrl'=' enlarge the image. Reference only bound Ctrl'=',
+    // which misses Ctrl'+' (Shift+= on US layouts) — ZoomIn covers that.
+    m_scAddView = new QShortcut(this);
+    m_scAddView->setKeys({QKeySequence::ZoomIn, QKeySequence("Ctrl+=")});
     m_scAddView->setContext(Qt::WindowShortcut);
     connect(m_scAddView, &QShortcut::activated, this, [ = ] {
         if (m_imageview)
@@ -425,7 +437,8 @@ void MainWidget::initShortcut()
         }
     });
 
-    m_scReduceView = new QShortcut(QKeySequence("Ctrl+-"), this);
+    m_scReduceView = new QShortcut(this);
+    m_scReduceView->setKeys({QKeySequence::ZoomOut, QKeySequence("Ctrl+-")});
     m_scReduceView->setContext(Qt::WindowShortcut);
     connect(m_scReduceView, &QShortcut::activated, this, [ = ] {
         if (m_imageview)
@@ -488,15 +501,19 @@ void MainWidget::runRec(bool needSetImage)
 
     createLoadingUi();
     m_plainTextEdit->clear();
+    m_ocrResult = {};
+    if (m_imageview) {
+        m_imageview->clearOcrResult();
+    }
     if(needSetImage) {
         OCREngine::instance()->setImage(*m_currentImg);
     }
     if (!m_loadImagethread) {
         m_loadImagethread = QThread::create([ = ]() {
-            m_result = OCREngine::instance()->getRecogitionResult();
+            const OcrResult result = OCREngine::instance()->getRecognitionResult();
             //判断程序是否退出
             if (1 == m_isEndThread) {
-                emit sigResult(m_result);
+                emit sigResult(result);
             }
         });
     }
@@ -521,26 +538,24 @@ void MainWidget::loadHtml(const QString &html)
     }
 }
 
-void MainWidget::loadString(const QString &string)
+void MainWidget::applyOcrResult(const OcrResult &result)
 {
-    if (!string.isEmpty()) {
+    m_ocrResult = result;
+    m_result = result.plainText;
+    if (!result.plainText.isEmpty()) {
         m_plainTextEdit->setUndoRedoEnabled(false);
         m_frameStackLayout->setContentsMargins(20, 0, 5, 0);
         m_resultWidget->setCurrentWidget(m_plainTextEdit);
-        m_plainTextEdit->appendPlainText(string);
-//        m_plainTextEdit->setText(string);
-        //读取完了显示在最上方
-        m_plainTextEdit->moveCursor(QTextCursor::Start) ;
-        m_plainTextEdit->ensureCursorVisible();
+        m_plainTextEdit->setPlainTextResult(result.plainText);
         m_plainTextEdit->setUndoRedoEnabled(true);
-        //新增识别完成按钮恢复
-        if (m_copyBtn) {
-            m_copyBtn->setEnabled(true);
-        }
+        m_imageview->setOcrResult(result);
+        m_imageview->setFocus();
         if (m_exportBtn) {
             m_exportBtn->setEnabled(true);
         }
+        updateCopyActionState();
     } else {
+        m_imageview->clearOcrResult();
         resultEmpty();
         m_noResult->setVisible(true);
     }
@@ -555,6 +570,8 @@ void MainWidget::resultEmpty()
     //修复未识别到文字没有居中对齐的问题
     m_frameStackLayout->setContentsMargins(20, 0, 20, 0);
     m_resultWidget->setCurrentWidget(m_noResult);
+    m_imageview->clearOcrResult();
+    m_ocrResult = {};
     //新增如果未识别到，按钮置灰
     if (m_copyBtn) {
         m_copyBtn->setEnabled(false);
@@ -615,18 +632,26 @@ void MainWidget::paintEvent(QPaintEvent *event)
 
 void MainWidget::slotCopy()
 {
-    //选中内容则复制，未选中内容则不复制
-    if (!m_plainTextEdit->textCursor().selectedText().isEmpty()) {
-        m_plainTextEdit->copy();
-    } else {
-        QTextDocument *document = m_plainTextEdit->document();
-        QPlainTextEdit *tempTextEdit = new QPlainTextEdit(this);
-        tempTextEdit->setDocument(document);
-        tempTextEdit->selectAll();
-        tempTextEdit->copy();
-        tempTextEdit->deleteLater();
-        tempTextEdit = nullptr;
+    copyCurrentSelection();
+}
+
+void MainWidget::copyCurrentSelection()
+{
+    QString copiedText;
+    if (m_imageview && m_imageview->hasSelection()) {
+        copiedText = m_imageview->selectedText();
+    } else if (m_plainTextEdit) {
+        const auto textRange = m_plainTextEdit->plainTextSelectionRange();
+        if (textRange.first != textRange.second) {
+            copiedText = m_ocrResult.textInRange(textRange.first, textRange.second);
+        }
     }
+
+    if (copiedText.isEmpty()) {
+        return;
+    }
+
+    QApplication::clipboard()->setText(copiedText);
 
     QIcon icon(":/assets/icon_toast_sucess_new.svg");
     DFloatingMessage *pDFloatingMessage = new DFloatingMessage(DFloatingMessage::MessageType::TransientType, m_pwidget);
@@ -635,7 +660,44 @@ void MainWidget::slotCopy()
     pDFloatingMessage->setIcon(icon);
     pDFloatingMessage->raise();
     DMessageManager::instance()->sendMessage(m_pwidget, pDFloatingMessage);
+}
 
+void MainWidget::updateCopyActionState()
+{
+    if (!m_copyBtn) {
+        return;
+    }
+
+    const bool hasImageSelection = m_imageview && m_imageview->hasSelection();
+    const auto textRange = m_plainTextEdit ? m_plainTextEdit->plainTextSelectionRange() : QPair<int, int>{-1, -1};
+    const bool hasTextSelection = textRange.first != textRange.second;
+    m_copyBtn->setEnabled(hasImageSelection || hasTextSelection);
+}
+
+void MainWidget::syncSelectionFromImage(const QList<QPair<int, int>> &ranges)
+{
+    if (m_syncingSelection) {
+        return;
+    }
+    m_syncingSelection = true;
+    m_plainTextEdit->selectPlainTextRanges(ranges);
+    m_syncingSelection = false;
+    updateCopyActionState();
+}
+
+void MainWidget::syncSelectionFromText(int start, int end)
+{
+    if (m_syncingSelection) {
+        return;
+    }
+    m_syncingSelection = true;
+    if (start >= 0 && end > start) {
+        m_imageview->selectRange(start, end);
+    } else {
+        m_imageview->selectRange(-1, -1);
+    }
+    m_syncingSelection = false;
+    updateCopyActionState();
 }
 
 void MainWidget::slotExport()

--- a/src/mainwidget.h
+++ b/src/mainwidget.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +21,7 @@
 
 #include "textloadwidget.h"
 #include "engine/OCREngine.h"
+#include "engine/OcrResult.h"
 
 class Frame;
 class QThread;
@@ -53,7 +54,7 @@ public:
     void openImage(const QImage &img, const QString &name = "");
 
     void loadHtml(const QString &html);
-    void loadString(const QString &string);
+    void applyOcrResult(const OcrResult &result);
     void resultEmpty();
 
     //缩放显示label
@@ -66,6 +67,10 @@ private slots:
     void slotCopy();
     void slotExport();
     void runRec(bool needSetImage);
+    void syncSelectionFromImage(const QList<QPair<int, int>> &ranges);
+    void syncSelectionFromText(int start, int end);
+    void copyCurrentSelection();
+    void updateCopyActionState();
 private:
     QGridLayout *m_mainGridLayout{nullptr};
     QHBoxLayout *m_horizontalLayout{nullptr};
@@ -96,6 +101,8 @@ private:
     QThread *m_loadImagethread{nullptr};
     QMutex m_mutex;
     QString m_result;
+    OcrResult m_ocrResult;
+    bool m_syncingSelection = false;
     QImage *m_currentImg{nullptr};
 
     DStackedWidget *m_resultWidget{nullptr};
@@ -113,7 +120,7 @@ private:
     DComboBox *languageSelectBox {nullptr}; // 语言选择框
 
 signals:
-    void sigResult(const QString &);
+    void sigResult(const OcrResult &result);
 
 };
 

--- a/src/resulttextview.cpp
+++ b/src/resulttextview.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -9,6 +9,11 @@
 #include <QClipboard>
 #include <QApplication>
 #include <QScrollBar>
+#include <QTextCursor>
+#include <QTimer>
+#include <DGuiApplicationHelper>
+
+DGUI_USE_NAMESPACE
 
 #include <math.h>
 
@@ -52,6 +57,14 @@ ResultTextView::ResultTextView(QWidget *parent)
         emit this->paste();
     });
     connect(this, &QPlainTextEdit::selectionChanged, this, &ResultTextView::onSelectionArea);
+    connect(this, &QPlainTextEdit::selectionChanged, this, [this]() {
+        if (m_blockSelectionSignal) {
+            return;
+        }
+        const int start = textCursor().selectionStart();
+        const int end = textCursor().selectionEnd();
+        emit textSelectionChanged(start, end);
+    });
     setFrameShape(QFrame::NoFrame);
     setFocusPolicy(Qt::StrongFocus);
     setMouseTracking(true);
@@ -352,4 +365,68 @@ void ResultTextView::onSelectionArea()
             setTextCursor(cursor);
         }
     }
+}
+
+void ResultTextView::setPlainTextResult(const QString &text)
+{
+    m_blockSelectionSignal = true;
+    setPlainText(text);
+    moveCursor(QTextCursor::Start);
+    m_blockSelectionSignal = false;
+}
+
+QPair<int, int> ResultTextView::plainTextSelectionRange() const
+{
+    return {textCursor().selectionStart(), textCursor().selectionEnd()};
+}
+
+void ResultTextView::selectPlainTextRanges(const QList<QPair<int, int>> &ranges)
+{
+    m_blockSelectionSignal = true;
+    if (ranges.isEmpty()) {
+        QTextCursor cursor = textCursor();
+        cursor.clearSelection();
+        setTextCursor(cursor);
+        setExtraSelections({});
+        QTimer::singleShot(0, this, [this]() { m_blockSelectionSignal = false; });
+        return;
+    }
+
+    if (ranges.size() == 1) {
+        const auto &range = ranges.first();
+        QTextCursor cursor = textCursor();
+        cursor.setPosition(range.first);
+        cursor.setPosition(range.second, QTextCursor::KeepAnchor);
+        setTextCursor(cursor);
+        setExtraSelections({});
+        QTimer::singleShot(0, this, [this]() { m_blockSelectionSignal = false; });
+        return;
+    }
+
+    QList<QTextEdit::ExtraSelection> extras;
+    extras.reserve(ranges.size());
+    // V-2325 v4 D3: theme color QPalette::Highlight (overrides reference fixed
+    // blue) for consistency with the left overlay highlight.
+    QColor highlightColor = DGuiApplicationHelper::instance()
+        ->applicationPalette().color(QPalette::Highlight);
+    highlightColor.setAlpha(80);
+    for (const auto &range : ranges) {
+        if (range.first < 0 || range.second <= range.first) {
+            continue;
+        }
+        QTextEdit::ExtraSelection selection;
+        selection.format.setBackground(highlightColor);
+        selection.cursor = textCursor();
+        selection.cursor.setPosition(range.first);
+        selection.cursor.setPosition(range.second, QTextCursor::KeepAnchor);
+        extras.append(selection);
+    }
+
+    QTextCursor cursor = textCursor();
+    const auto &firstRange = ranges.first();
+    cursor.setPosition(firstRange.first);
+    cursor.setPosition(firstRange.second, QTextCursor::KeepAnchor);
+    setTextCursor(cursor);
+    setExtraSelections(extras);
+    QTimer::singleShot(0, this, [this]() { m_blockSelectionSignal = false; });
 }

--- a/src/resulttextview.h
+++ b/src/resulttextview.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -41,6 +41,11 @@ private slots:
     void onSelectionArea();
 signals:
     void sigChangeSize();
+    void textSelectionChanged(int start, int end);
+public:
+    void setPlainTextResult(const QString &text);
+    QPair<int, int> plainTextSelectionRange() const;
+    void selectPlainTextRanges(const QList<QPair<int, int>> &ranges);
 private:
     QMenu *m_Menu{nullptr};
     QAction *m_actCopy{nullptr};
@@ -79,6 +84,7 @@ private:
     qreal m_currentStepScaleFactor = 1;
     Qt::GestureState m_tapStatus = Qt::NoGesture;
     int m_fontSize = 16;
+    bool m_blockSelectionSignal = false;
 };
 
 #endif // RESULTTEXTVIEW_H

--- a/src/view/imageview.cpp
+++ b/src/view/imageview.cpp
@@ -1,4 +1,4 @@
-﻿// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+﻿// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -17,6 +17,19 @@
 #include <QObject>
 #include <QGestureEvent>
 #include <QPinchGesture>
+#include <QContextMenuEvent>
+#include <QKeyEvent>
+#include <QMouseEvent>
+#include <QScrollBar>
+#include <QAction>
+#include <QMenu>
+#include <QPainter>
+#include <QClipboard>
+#include <QApplication>
+#include <QLineF>
+#include <DGuiApplicationHelper>
+
+DGUI_USE_NAMESPACE
 
 const qreal MAX_SCALE_FACTOR = 20.0;
 const qreal MIN_SCALE_FACTOR = 0.029;
@@ -32,7 +45,15 @@ ImageView::ImageView(QWidget *parent):
     setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     this->grabGesture(Qt::PinchGesture);
     setAttribute(Qt::WA_AcceptTouchEvents);
+    setFocusPolicy(Qt::StrongFocus);
     viewport()->setCursor(Qt::ArrowCursor);
+
+    m_contextMenu = new QMenu(this);
+    auto *selectAllAction = m_contextMenu->addAction(tr("Select All"));
+    auto *copyAction = m_contextMenu->addAction(tr("Copy"));
+    copyAction->setObjectName(QStringLiteral("ocrCopyAction"));
+    connect(selectAllAction, &QAction::triggered, this, &ImageView::selectAllText);
+    connect(copyAction, &QAction::triggered, this, &ImageView::copyRequested);
 }
 
 ImageView::~ImageView()
@@ -74,6 +95,7 @@ void ImageView::openImage(const QString &path)
 void ImageView::openFilterImage(QImage img)
 {
     qCInfo(dmOcr) << "Opening filtered image, size:" << img.size();
+    clearOcrResult();
     if (!img.isNull() && scene()) {
         m_FilterImage = img;
     }
@@ -196,21 +218,113 @@ void ImageView::autoFit()
 
 void ImageView::mouseReleaseEvent(QMouseEvent *e)
 {
+    if (m_isTextSelecting) {
+        m_isTextSelecting = false;
+        e->accept();
+        return;
+    }
+    if (m_isPanning) {
+        m_isPanning = false;
+        e->accept();
+        return;
+    }
     QGraphicsView::mouseReleaseEvent(e);
-    viewport()->setCursor(Qt::ArrowCursor);
+    updateCursorForImagePos(mapToImagePos(e->pos()));
 }
 
 void ImageView::mousePressEvent(QMouseEvent *e)
 {
+    // V-2325 v4 C4: Ctrl+left-drag pans the image; plain left-drag does manual
+    // lasso text selection. (Reference used middle-button pan — overridden to
+    // Ctrl+left so the common "drag to select text" gesture stays on left.)
+    if (!m_ocrResult.isEmpty() && e->button() == Qt::LeftButton
+        && (e->modifiers() & Qt::ControlModifier)) {
+        m_isPanning = true;
+        m_lastPanPos = e->pos();
+        viewport()->setCursor(Qt::ClosedHandCursor);
+        e->accept();
+        return;
+    }
+
+    if (!m_ocrResult.isEmpty() && e->button() == Qt::LeftButton) {
+        const QPointF imagePos = mapToImagePos(e->pos());
+        m_dragAnchorPos = imagePos;
+        m_isTextSelecting = true;
+
+        const int charIndex = m_ocrResult.charIndexAt(imagePos);
+        if (charIndex >= 0) {
+            const auto &item = m_ocrResult.allChars.at(charIndex);
+            setSelectionRanges({qMakePair(item.plainTextStart, item.plainTextEnd)});
+        } else {
+            setSelectionRanges({});
+        }
+        setFocus();
+        e->accept();
+        return;
+    }
+
+    if (m_ocrResult.isEmpty()) {
+        QGraphicsView::mousePressEvent(e);
+        viewport()->unsetCursor();
+        viewport()->setCursor(Qt::ArrowCursor);
+        return;
+    }
+
+    // Non-left buttons (middle/right) with OCR result present: forward to the
+    // base class so its default behaviors (e.g. middle-button auto-scroll) keep
+    // working instead of being swallowed.
     QGraphicsView::mousePressEvent(e);
-    viewport()->unsetCursor();
-    viewport()->setCursor(Qt::ArrowCursor);
+}
+
+void ImageView::mouseDoubleClickEvent(QMouseEvent *event)
+{
+    // V-2325 v4 D1: double-click selects ONLY the single clicked char (not the
+    // whole line as in the reference). Use charIndexAt to find the char and
+    // select exactly its [plainTextStart, plainTextEnd) range.
+    if (!m_ocrResult.isEmpty() && event->button() == Qt::LeftButton) {
+        const QPointF imagePos = mapToImagePos(event->pos());
+        const int charIndex = m_ocrResult.charIndexAt(imagePos);
+        if (charIndex >= 0) {
+            const auto &item = m_ocrResult.allChars.at(charIndex);
+            setSelectionRanges({qMakePair(item.plainTextStart, item.plainTextEnd)});
+        } else {
+            setSelectionRanges({});
+        }
+        event->accept();
+        return;
+    }
+    QGraphicsView::mouseDoubleClickEvent(event);
 }
 
 void ImageView::mouseMoveEvent(QMouseEvent *event)
 {
-    //修复鼠标状态不对的问题
-    if (!(event->buttons() | Qt::NoButton)) {
+    if (m_isPanning) {
+        const QPoint delta = event->pos() - m_lastPanPos;
+        m_lastPanPos = event->pos();
+        horizontalScrollBar()->setValue(horizontalScrollBar()->value() - delta.x());
+        verticalScrollBar()->setValue(verticalScrollBar()->value() - delta.y());
+        event->accept();
+        return;
+    }
+
+    if (m_isTextSelecting && (event->buttons() & Qt::LeftButton) && !m_ocrResult.isEmpty()) {
+        const QPointF currentPos = mapToImagePos(event->pos());
+        QRectF dragRect = QRectF(m_dragAnchorPos, currentPos).normalized();
+        if (dragRect.width() < 2.0 && dragRect.height() < 2.0) {
+            dragRect = QRectF(currentPos.x() - 1.0, currentPos.y() - 1.0, 2.0, 2.0);
+        }
+        setSelectionRanges(m_ocrResult.plainTextRangesForRect(dragRect));
+        event->accept();
+        return;
+    }
+
+    if (!m_ocrResult.isEmpty()) {
+        updateCursorForImagePos(mapToImagePos(event->pos()));
+        event->accept();
+        return;
+    }
+
+    if (event->buttons() == Qt::NoButton) {
         viewport()->setCursor(Qt::ArrowCursor);
     } else {
         QGraphicsView::mouseMoveEvent(event);
@@ -333,5 +447,165 @@ void ImageView::setScaleValue(qreal v)
     emit scaled(m_scal * 100);
     emit showScaleLabel();
 
+}
+
+void ImageView::setOcrResult(const OcrResult &result)
+{
+    m_ocrResult = result;
+    m_selRanges.clear();
+    m_focusRanges.clear();
+    setDragMode(QGraphicsView::NoDrag);
+    viewport()->update();
+}
+
+void ImageView::clearOcrResult()
+{
+    m_ocrResult = {};
+    m_selRanges.clear();
+    m_focusRanges.clear();
+    setDragMode(QGraphicsView::ScrollHandDrag);
+    viewport()->update();
+}
+
+void ImageView::selectAllText()
+{
+    if (m_ocrResult.plainText.isEmpty()) {
+        setSelectionRanges({});
+        return;
+    }
+    setSelectionRanges({qMakePair(0, m_ocrResult.plainText.size())});
+}
+
+void ImageView::selectRange(int start, int end)
+{
+    // V-2325 v4 D3: right→left linkage sets the FOCUS tier (α55), distinct from
+    // the user's own left selection (m_selRanges, α90). emitSignal=false to
+    // avoid retriggering left→right (anti-loop via m_syncingSelection in
+    // MainWidget).
+    if (start < 0 || end <= start) {
+        m_focusRanges.clear();
+    } else {
+        m_focusRanges = {qMakePair(start, end)};
+    }
+    viewport()->update();
+}
+
+bool ImageView::hasSelection() const
+{
+    return !m_selRanges.isEmpty();
+}
+
+QString ImageView::selectedText() const
+{
+    return m_ocrResult.textInRanges(m_selRanges);
+}
+
+QList<QPair<int, int>> ImageView::selectionRanges() const
+{
+    return m_selRanges;
+}
+
+QPointF ImageView::mapToImagePos(const QPoint &viewPos) const
+{
+    return mapToScene(viewPos);
+}
+
+void ImageView::setSelectionRanges(const QList<QPair<int, int>> &ranges, bool emitSignal)
+{
+    m_selRanges = ranges;
+    viewport()->update();
+    if (emitSignal) {
+        emit selectionRangesChanged(ranges);
+    }
+}
+
+void ImageView::updateCursorForImagePos(const QPointF &imagePos)
+{
+    if (m_ocrResult.isEmpty()) {
+        viewport()->setCursor(Qt::ArrowCursor);
+        return;
+    }
+
+    const int charIndex = m_ocrResult.charIndexAt(imagePos);
+    viewport()->setCursor(charIndex >= 0 ? Qt::IBeamCursor : Qt::ArrowCursor);
+}
+
+void ImageView::drawForeground(QPainter *painter, const QRectF &rect)
+{
+    Q_UNUSED(rect)
+    if (m_ocrResult.isEmpty()) {
+        return;
+    }
+
+    painter->save();
+    painter->setRenderHint(QPainter::Antialiasing, true);
+    painter->setPen(Qt::NoPen);  // V-2325 v4 D3: no outline (no border/seam)
+
+    // V-2325 v4 D3: theme color QPalette::Highlight (overrides reference fixed
+    // blue). Re-read on every paint so theme switches take effect immediately.
+    const QColor highlight = DGuiApplicationHelper::instance()
+        ->applicationPalette().color(QPalette::Highlight);
+
+    // Focus tier (right→left linkage): α55, drawn first (lower z).
+    if (!m_focusRanges.isEmpty()) {
+        const auto focusAreas = m_ocrResult.highlightRectsForRanges(m_focusRanges);
+        QColor focusColor = highlight;
+        focusColor.setAlpha(55);
+        painter->setBrush(focusColor);
+        for (const QRectF &area : focusAreas) {
+            if (!area.isEmpty()) {
+                painter->drawRect(area);
+            }
+        }
+    }
+
+    // Selection tier (user left lasso/double-click/select-all): α90, on top.
+    if (hasSelection()) {
+        const auto highlightAreas = m_ocrResult.highlightRectsForRanges(m_selRanges);
+        QColor selColor = highlight;
+        selColor.setAlpha(90);
+        painter->setBrush(selColor);
+        for (const QRectF &area : highlightAreas) {
+            if (!area.isEmpty()) {
+                painter->drawRect(area);
+            }
+        }
+    }
+
+    painter->restore();
+}
+
+void ImageView::contextMenuEvent(QContextMenuEvent *event)
+{
+    if (m_ocrResult.isEmpty() || m_contextMenu == nullptr) {
+        QGraphicsView::contextMenuEvent(event);
+        return;
+    }
+
+    for (QAction *action : m_contextMenu->actions()) {
+        if (action->objectName() == QStringLiteral("ocrCopyAction")) {
+            action->setEnabled(hasSelection());
+        }
+    }
+    m_contextMenu->exec(event->globalPos());
+}
+
+void ImageView::keyPressEvent(QKeyEvent *event)
+{
+    if (!m_ocrResult.isEmpty() && event->matches(QKeySequence::SelectAll)) {
+        selectAllText();
+        event->accept();
+        return;
+    }
+
+    if (!m_ocrResult.isEmpty() && event->matches(QKeySequence::Copy)) {
+        if (hasSelection()) {
+            emit copyRequested();
+        }
+        event->accept();
+        return;
+    }
+
+    QGraphicsView::keyPressEvent(event);
 }
 

--- a/src/view/imageview.h
+++ b/src/view/imageview.h
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2022 UnionTech Software Technology Co., Ltd.
+// SPDX-FileCopyrightText: 2022-2026 UnionTech Software Technology Co., Ltd.
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -10,9 +10,12 @@
 
 #include <QGraphicsView>
 
+#include "engine/OcrResult.h"
+
 class QGraphicsPixmapItem;
 class QGestureEvent;
 class QPinchGesture;
+class QMenu;
 
 class ImageView : public QGraphicsView
 {
@@ -34,12 +37,21 @@ public:
     void mouseReleaseEvent(QMouseEvent *e) override;
     void mousePressEvent(QMouseEvent *e) override;
     void mouseMoveEvent(QMouseEvent *e) override;
+    void mouseDoubleClickEvent(QMouseEvent *event) override;
     bool event(QEvent *event)override;
     bool gestureEvent(QGestureEvent *event);
 
     //返回当前图片img
     const QImage image();
     void openFilterImage(QImage img);
+
+    void setOcrResult(const OcrResult &result);
+    void clearOcrResult();
+    void selectAllText();
+    void selectRange(int start, int end);
+    bool hasSelection() const;
+    QString selectedText() const;
+    QList<QPair<int, int>> selectionRanges() const;
 public slots:
     //适应窗口大小
     void fitWindow();
@@ -47,21 +59,28 @@ public slots:
     void fitImage();
     //旋转图片，感觉index角度，-为左，+为右
     void RotateImage(const int &index);
-//    //打开该图片
-//    void openImage(QImage *img);
 
     //窗口大小改变事件
     void resizeEvent(QResizeEvent *event) override;
     //鼠标滚轮事件
     void wheelEvent(QWheelEvent *event) override;
 protected:
+    void drawForeground(QPainter *painter, const QRectF &rect) override;
+    void contextMenuEvent(QContextMenuEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
     //二指捏合功能的触屏事件
     void handleGestureEvent(QGestureEvent *gesture);
     void pinchTriggered(QPinchGesture *gesture);
 signals:
     void scaled(qreal perc);
     void showScaleLabel();
+    void selectionRangesChanged(const QList<QPair<int, int>> &ranges);
+    void copyRequested();
 private:
+    QPointF mapToImagePos(const QPoint &viewPos) const;
+    void setSelectionRanges(const QList<QPair<int, int>> &ranges, bool emitSignal = true);
+    void updateCursorForImagePos(const QPointF &imagePos);
+
     QString m_currentPath;//当前图片路径
     QGraphicsPixmapItem *m_pixmapItem{nullptr};//当前图像的item
     bool m_isFitImage = false;//是否适应图片
@@ -72,6 +91,14 @@ private:
     QImage m_FilterImage{nullptr};//当前处理的图像
     QImage m_lightContrastImage{nullptr};//亮度曝光度图像
 
+    OcrResult m_ocrResult;
+    QList<QPair<int, int>> m_selRanges;     // V-2325 v4: user left selection (α90)
+    QList<QPair<int, int>> m_focusRanges;   // V-2325 v4 D3: right→left linked focus (α55)
+    QPointF m_dragAnchorPos;
+    bool m_isTextSelecting = false;
+    bool m_isPanning = false;
+    QPoint m_lastPanPos;
+    QMenu *m_contextMenu = nullptr;
 };
 
 #endif // IMAGEVIEW_H


### PR DESCRIPTION
## feat: enhance OCR text extraction with char-level selection and linkage

### 改动范围

OCR 文字提取增强：在左侧 OCR 图片视图上实现字符级文本选择，并与右侧文本面板双向联动高亮。

**新增（2 文件）**
- `src/engine/OcrResult.h` / `OcrResult.cpp` — 结构化 OCR 结果模型

**修改（10 文件）**
- `src/engine/OCREngine.h` / `.cpp` — `getRecognitionResult()` 返回 `OcrResult`
- `src/view/imageview.h` / `.cpp` — 字符级选择 + `drawForeground` 直绘高亮
- `src/resulttextview.h` / `.cpp` — `setPlainTextResult` / 多段高亮选择
- `src/mainwidget.h` / `.cpp` — 双向联动 + 防回环 + Ctrl'+' 快捷键修复
- `src/main.cpp` — `qRegisterMetaType<OcrResult>`
- `.gitignore`

### 实现要点

- **字符框合成（1:1 恒成立）**：当引擎 `charBoxes` 数量与行文本长度不等时，按显示权重（CJK=2.0/Latin=1.0）在行框内按比例合成每字一框，保证每个文本字符恒有框，左右 1:1 对应恒成立，不再整行丢弃。
- **`drawForeground` 直绘**：高亮直接在 `ImageView::drawForeground` 用 `QPainter::drawRect` 绘制，`Qt::NoPen` + `QPalette::Highlight` 主题色；每行连续选中字 `united` 成一条连续高亮条，无 `QGraphicsItem`、无 `RubberBandDrag`，杜绝小方块/接缝/虚线。
- **`plainText` 单一真源**：右侧 `setPlainText` 内容即左侧偏移源，文档位置 i = `plainText[i]`，`\n`/空格自然占位，替代旧 `displayOffset` 间接层。
- **手动套索**：`mouseMoveEvent` 调 `plainTextRangesForRect(dragRect)` 计算选中范围，不用 Qt RubberBand。
- **`charIndexAt` 严格命中**：仅 `textBoxContains` 命中返回，跳过空白字符，点空白返回 -1 不选中。
- **双击选单字（D1）**：双击只选中所点单个字符。
- **主题色（D3）**：`QPalette::Highlight`，选中层 α90 / 右→左聚焦层 α55，主题切换自动跟随。
- **Ctrl+左键平移 / 左键套索（C4）**：Ctrl+左键拖拽平移图片，左键拖拽手动套索；无覆盖层时 ScrollHandDrag。
- **菜单两态（C5）**：左侧右键 Select All / Copy，按是否有选中启用 Copy。
- **双向联动（C6）**：左右选择 best-effort 联动，`m_syncingSelection` 防回环。
- **段落自动换行（R9）**：视觉行分组 `groupIntoVisualLines` + `needSpaceBetweenBoxes`，合并换行为段落。
- **Ctrl'+' 修复**：`setKeys({QKeySequence::ZoomIn, QKeySequence("Ctrl+=")})` 双绑定，同时支持 Ctrl'+' 与 Ctrl'=' 放大。
- **无新增翻译（C7）**：仅 `tr("Select All")` / `tr("Copy")`。

## Summary by Sourcery

Enhance OCR extraction with structured character geometry and synchronized text selection across the image and text views.

New Features:
- Add character-level OCR selection on the image view, including lasso, single-character double-click, select-all, copy, and theme-aware highlighting.
- Enable bidirectional selection and focus synchronization between the OCR image and text panels.
- Introduce structured OCR results with character and line geometry for accurate text-to-image mapping.

Bug Fixes:
- Improve OCR text assembly when character box counts differ from line text lengths by synthesizing per-character regions instead of dropping lines.
- Fix zoom shortcuts to support both Ctrl+'+' and Ctrl+'=' along with zoom-out key variants.

Enhancements:
- Improve OCR layout reconstruction with visual-line grouping, spacing detection, strict character hit testing, and unified highlight regions.
- Update copy behavior and action state to reflect selections from either OCR view.

Chores:
- Register the structured OCR result type for Qt signal transport.