### PR TITLE
fix: throttle wheel zoom to avoid GPU crash

### DIFF
--- a/src/view/imageview.cpp
+++ b/src/view/imageview.cpp
@@ -16,6 +16,7 @@
 #include <QObject>
 #include <QGestureEvent>
 #include <QPinchGesture>
+#include <QTimer>
 
 const qreal MAX_SCALE_FACTOR = 20.0;
 const qreal MIN_SCALE_FACTOR = 0.029;
@@ -32,6 +33,11 @@ ImageView::ImageView(QWidget *parent):
     this->grabGesture(Qt::PinchGesture);
     setAttribute(Qt::WA_AcceptTouchEvents);
     viewport()->setCursor(Qt::ArrowCursor);
+
+    m_wheelTimer = new QTimer(this);
+    m_wheelTimer->setSingleShot(true);
+    m_wheelTimer->setInterval(50);
+    connect(m_wheelTimer, &QTimer::timeout, this, &ImageView::onWheelTimerTimeout);
 }
 
 ImageView::~ImageView()
@@ -243,10 +249,39 @@ void ImageView::resizeEvent(QResizeEvent *event)
 
 void ImageView::wheelEvent(QWheelEvent *event)
 {
-    qreal factor = qPow(1.2, event->delta() / 240.0);
-    scaleAtPoint(event->pos(), factor);
+    const int delta = event->angleDelta().y();
+    if (delta == 0) {
+        event->accept();
+        return;
+    }
+
+    // Accumulate wheel events and defer the repaint to a timer to avoid
+    // per-event full repaint that overloads weak GPUs.
+    m_accumulatedFactor *= qPow(1.2, delta / 240.0);
+    m_wheelPos = event->position().toPoint();
+
+    if (!m_isZooming) {
+        m_isZooming = true;
+        if (m_pixmapItem)
+            m_pixmapItem->setTransformationMode(Qt::FastTransformation);
+    }
+    m_wheelTimer->start();
 
     event->accept();
+}
+
+void ImageView::onWheelTimerTimeout()
+{
+    if (!m_isZooming)
+        return;
+
+    scaleAtPoint(m_wheelPos, m_accumulatedFactor);
+    m_accumulatedFactor = 1.0;
+    m_isZooming = false;
+
+    // Restore smooth rendering once the zoom interaction settles.
+    if (m_pixmapItem)
+        m_pixmapItem->setTransformationMode(Qt::SmoothTransformation);
 }
 
 void ImageView::handleGestureEvent(QGestureEvent *gesture)
@@ -271,9 +306,14 @@ void ImageView::pinchTriggered(QPinchGesture *gesture)
 }
 void ImageView::scaleAtPoint(QPoint pos, qreal factor)
 {
+    if (!qIsFinite(factor) || factor <= 0.0)
+        return;
+
     // Remember zoom anchor point.
     const QPointF targetPos = pos;
     const QPointF targetScenePos = mapToScene(targetPos.toPoint());
+    if (!qIsFinite(targetScenePos.x()) || !qIsFinite(targetScenePos.y()))
+        return;
 
     // Do the scaling.
     setScaleValue(factor);
@@ -285,38 +325,29 @@ void ImageView::scaleAtPoint(QPoint pos, qreal factor)
     const QPointF curPos = mapFromScene(targetScenePos);
     const QPointF centerPos = QPointF(width() / 2.0, height() / 2.0) + (curPos - targetPos);
     const QPointF centerScenePos = mapToScene(centerPos.toPoint());
+    if (!qIsFinite(centerScenePos.x()) || !qIsFinite(centerScenePos.y()))
+        return;
     centerOn(static_cast<int>(centerScenePos.x()), static_cast<int>(centerScenePos.y()));
 }
 void ImageView::setScaleValue(qreal v)
 {
     //由于矩阵被旋转，通过矩阵获取缩放因子，计算缩放比例错误，因此记录过程中的缩放因子来判断缩放比例
+    // Clamp the factor before applying scale() to avoid overshoot and the
+    // extra repaint caused by the previous apply-then-rollback approach.
+    const qreal projected = m_scal * v;
+    if (projected < MIN_SCALE_FACTOR) {
+        v = MIN_SCALE_FACTOR / m_scal;
+    } else if (projected > MAX_SCALE_FACTOR) {
+        v = MAX_SCALE_FACTOR / m_scal;
+    }
+
     m_scal *= v;
     qDebug() << m_scal;
     scale(v, v);
-    //const qreal irs = imageRelativeScale() * devicePixelRatioF();
-    // Rollback
-    if (v < 1 && /*irs <= MIN_SCALE_FACTOR)*/m_scal < 0.03) {
-        const qreal minv = MIN_SCALE_FACTOR / m_scal;
-        // if (minv < 1.09) return;
-        scale(minv, minv);
-        m_scal *= minv;
-    } else if (v > 1 && /*irs >= MAX_SCALE_FACTOR*/m_scal > 20) {
-        const qreal maxv = MAX_SCALE_FACTOR / m_scal;
-        scale(maxv, maxv);
-        m_scal *= maxv;
-    } else {
-        m_isFitImage = false;
-        m_isFitWindow = false;
-    }
+    m_isFitImage = false;
+    m_isFitWindow = false;
 
-//    qreal rescale = imageRelativeScale() * devicePixelRatioF();
-    //    if (rescale - 1 > -0.01 && rescale - 1 < 0.01) {
-    //        emit checkAdaptImageBtn();
-    //    } else {
-    //        emit disCheckAdaptImageBtn();
-    //    }
     emit scaled(m_scal * 100);
     emit showScaleLabel();
-
 }
 

--- a/src/view/imageview.h
+++ b/src/view/imageview.h
@@ -9,6 +9,7 @@
 #define IMAGEVIEW_H
 
 #include <QGraphicsView>
+#include <QTimer>
 
 class QGraphicsPixmapItem;
 class QGestureEvent;
@@ -61,6 +62,8 @@ protected:
 signals:
     void scaled(qreal perc);
     void showScaleLabel();
+private slots:
+    void onWheelTimerTimeout();
 private:
     QString m_currentPath;//当前图片路径
     QGraphicsPixmapItem *m_pixmapItem{nullptr};//当前图像的item
@@ -71,6 +74,10 @@ private:
     QImage *m_currentImage{nullptr};//当前原始图像
     QImage m_FilterImage{nullptr};//当前处理的图像
     QImage m_lightContrastImage{nullptr};//亮度曝光度图像
+    QTimer *m_wheelTimer{nullptr};
+    qreal m_accumulatedFactor = 1.0;
+    QPoint m_wheelPos;
+    bool m_isZooming = false;
 
 };
 


### PR DESCRIPTION
## Root Cause Analysis

The OCR image viewer's `ImageView::wheelEvent` (`src/view/imageview.cpp:244`) is the only wheel handler in the repository. It used the deprecated `delta()`/`pos()` API with no throttling or event merging, triggering a full `scale()` repaint on every single wheel event. Combined with `Qt::SmoothTransformation` being permanently enabled on the pixmap item (`:59`, `:81`), this causes GPU render overload on weak hardware such as the L420, manifesting as stuttering followed by a crash/exit. A full-text search of `src/` found no `exit`/`quit`/`abort`/`close` calls, confirming the exit is a crash rather than a voluntary exit. This is a high-confidence hypothesis (no core dump or stack trace is available).

Key evidence: the single wheel path `wheelEvent` → `scaleAtPoint` (`:272-289`) → `setScaleValue` (`:290-320`) → `scale()` repaint; and `setScaleValue` applying `scale()` unconditionally before boundary rollback (`:290-320`).

## Fix

Implemented all five recommendations from the analysis report:
1. **Wheel event throttle**: accumulate wheel deltas via a 50ms single-shot `QTimer`, applying the merged scale factor once instead of repainting per event.
2. **Deprecated API replacement**: `event->delta()` → `event->angleDelta().y()`, `event->pos()` → `event->position().toPoint()`, with a guard for zero delta.
3. **Render cost control**: switch the pixmap item to `Qt::FastTransformation` during zoom, restore `Qt::SmoothTransformation` after the zoom interaction settles.
4. **Boundary check pre-move**: clamp the projected scale factor to `[MIN_SCALE_FACTOR, MAX_SCALE_FACTOR]` *before* calling `scale()`, eliminating the apply-then-rollback repaint.
5. **Stability guards**: add `qIsFinite` validation on the scale factor and on `mapToScene`/`centerOn` results to guard against degenerate transforms.

No public API or signature changes; `pinchTriggered` (touch pinch zoom) is unaffected since it calls `scaleAtPoint` directly without the throttle.

## Change Safety Assessment

### Code Safety

- **Risk Level**: Medium
- Target code is the baseline sync commit `c12efa8` (a GitHub workflow sync commit with no prior bug-fix history), so this change does not revert any historical fix.
- `wheelEvent`/`setScaleValue` signatures are unchanged; the highest-risk affected caller `pinchTriggered` (`:230`) calls `scaleAtPoint` directly and is not affected by the wheel throttle.

### Business Impact Scope

- **Mouse wheel zoom**: now throttled for smoother rendering — the primary fix target. Verify rapid wheel scroll on weak-GPU hardware no longer stutters/crashes.
- **Touch pinch zoom**: functionally unchanged (calls `scaleAtPoint` directly). Verify pinch zoom still works and the anchor/centering is correct.
- **Zoom to boundary**: boundary rollback now pre-clamps before `scale()`. Verify zooming past min/max boundaries behaves correctly.

### Verification Suggestion

Focus regression testing on rapid mouse-wheel zoom on weak-GPU hardware (L420): confirm no stutter/crash and that final image quality returns to smooth after zoom settles. Also verify pinch zoom and boundary rollback on normal hardware.

---

## 根因分析

OCR 图片查看器全仓唯一的滚轮处理 `ImageView::wheelEvent`（`src/view/imageview.cpp:244`）使用了过时的 `delta()`/`pos()` API，无节流/合并，逐事件触发全量 `scale()` 重绘。叠加图元始终开启 `Qt::SmoothTransformation`（`:59`、`:81`），在 L420 等弱 GPU 机型上导致渲染过载，表现为卡顿后崩溃/退出。全 `src/` 无 `exit`/`quit`/`abort`/`close` 主动退出代码，佐证退出为崩溃而非主动退出。结论为高置信假设（无 core dump / 堆栈）。

关键证据：唯一滚轮路径 `wheelEvent` → `scaleAtPoint`（`:272-289`）→ `setScaleValue`（`:290-320`）→ `scale()` 重绘；`setScaleValue` 先无条件 `scale()` 再边界回滚（`:290-320`）。

## 修复方案

实现了分析报告的全部五项建议：
1. **滚轮事件节流**：通过 50ms 单次触发 `QTimer` 累积滚轮 delta，合并为一次缩放，避免逐事件全量重绘。
2. **替换过时 API**：`event->delta()` → `event->angleDelta().y()`，`event->pos()` → `event->position().toPoint()`，并处理 delta 为 0 的情况。
3. **渲染开销控制**：缩放过程中临时使用 `Qt::FastTransformation`，缩放结束后恢复 `Qt::SmoothTransformation`。
4. **边界检查前置**：在调用 `scale()` 前将投影缩放因子钳制到 `[MIN_SCALE_FACTOR, MAX_SCALE_FACTOR]`，消除先应用后回滚的额外重绘。
5. **稳定性兜底**：对缩放因子及 `mapToScene`/`centerOn` 结果加 `qIsFinite` 校验，防止退化变换。

无公开 API 或签名变更；`pinchTriggered`（触屏捏合缩放）直接调用 `scaleAtPoint`，不受滚轮节流影响。

## 改动安全评估

### 代码安全评估

- **风险等级**: 中风险
- 目标代码为基线同步 commit `c12efa8`（GitHub workflow 同步提交，无此前 bug 修复历史），本次修改不存在撤销历史修复引入回归的风险。
- `wheelEvent`/`setScaleValue` 签名不变；最高风险调用方 `pinchTriggered`（`:230`）直接调用 `scaleAtPoint`，不受滚轮节流影响。

### 业务影响范围

- **鼠标滚轮缩放**：经节流后渲染更流畅——本次修复主要目标。弱 GPU 机型上快速滚轮缩放验证不再卡顿/崩溃。
- **触屏捏合缩放**：功能不变（直接调用 `scaleAtPoint`）。验证捏合缩放正常、锚点居中正确。
- **缩放至边界**：边界回滚改为 `scale()` 前预钳制。验证越过最大/最小边界后行为正常。

### 验证建议

回归测试重点：弱 GPU 机型（L420）上快速鼠标滚轮缩放，确认无卡顿/崩溃，且缩放结束后图片恢复平滑渲染。正常机型上验证捏合缩放与边界回滚。

## Summary by Sourcery

Stabilize image viewer wheel zoom by throttling updates, reducing transient rendering cost, and validating bounded scale transformations.

Bug Fixes:
- Prevent GPU overload and crashes during rapid mouse-wheel image zooming by batching zoom updates and reducing rendering cost during interaction.
- Guard image scaling and centering against invalid transforms and enforce zoom limits before applying changes.

Enhancements:
- Replace deprecated wheel-event APIs and preserve smooth image rendering after zoom interactions settle.
- Keep pinch zoom behavior unchanged while improving mouse-wheel zoom responsiveness.